### PR TITLE
add validation of fields in `Enrollment` file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,6 +299,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64-url"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5b428e9fb429c6fda7316e9b006f993e6b4c33005e4659339fb5214479dddec"
+dependencies = [
+ "base64 0.22.1",
+]
+
+[[package]]
 name = "base64ct"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,6 +782,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2 1.0.101",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "curve25519-dalek-ng"
 version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,6 +985,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1075,7 +1125,9 @@ dependencies = [
 name = "felidae-oracle"
 version = "0.1.0"
 dependencies = [
+ "base64-url",
  "canonical_json",
+ "ed25519-dalek",
  "felidae-types",
  "fqdn",
  "getrandom 0.2.16",
@@ -1194,6 +1246,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -3404,6 +3462,15 @@ name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,3 +57,5 @@ humantime = "2"
 canonical_json = "0.5"
 json-rpc-types = "1.3"
 tower-http = { version = "0.6", features = ["util", "normalize-path"] }
+base64-url = "3.0.2"
+ed25519-dalek = { version = "2.1", features = ["std"] }

--- a/crates/felidae-oracle/Cargo.toml
+++ b/crates/felidae-oracle/Cargo.toml
@@ -14,6 +14,8 @@ serde_json = { workspace = true }
 serde = { workspace = true }
 sha2 = { workspace = true }
 canonical_json = { workspace = true }
+base64-url = { workspace = true }
+ed25519-dalek = { workspace = true }
 
 [lib]
 crate-type = ["lib", "cdylib"]


### PR DESCRIPTION
Closes #21
This validates the fields described in the spec here: https://github.com/freedomofpress/webcat-spec/blob/main/server.md

TODO before ready:
- [x] Check keys are valid Ed25519
- [x] Check Sigsum policy is valid base64 (but I don't plan to do further validation) 