### PR TITLE
felidae start: CLI args for storage directory and host to bind to

### DIFF
--- a/crates/felidae/src/cli/start.rs
+++ b/crates/felidae/src/cli/start.rs
@@ -19,19 +19,29 @@ pub struct Start {
     /// Which port should the query server listen on?
     #[clap(long, default_value = "80")]
     query: u16,
+    /// Home directory for storing state (defaults to platform-specific directory).
+    #[clap(long)]
+    pub homedir: Option<std::path::PathBuf>,
 }
 
 impl Run for Start {
     async fn run(self) -> color_eyre::Result<()> {
-        let Self { abci, query } = self;
+        let Self {
+            abci,
+            query,
+            homedir,
+        } = self;
 
         // Determine the internal and canonical storage directories:
-        // TODO: allow overriding these via CLI args
-        let storage_dir = directories::ProjectDirs::from("press", "freedom", "felidae")
-            .ok_or_eyre("could not determine storage directory")?
-            .data_local_dir()
-            .join("storage")
-            .to_path_buf();
+        let storage_dir = if let Some(homedir) = homedir {
+            homedir.join("storage")
+        } else {
+            directories::ProjectDirs::from("press", "freedom", "felidae")
+                .ok_or_eyre("could not determine storage directory")?
+                .data_local_dir()
+                .join("storage")
+                .to_path_buf()
+        };
 
         // Load up the storage/state backend, which implements the ABCI service:
         let state = Store::init(storage_dir).await?;

--- a/crates/felidae/src/cli/start.rs
+++ b/crates/felidae/src/cli/start.rs
@@ -16,6 +16,9 @@ pub struct Start {
     /// Which port should the ABCI server listen on?
     #[clap(long, default_value = "26658")]
     abci: u16,
+    /// Which host/address should the ABCI server bind to?
+    #[clap(long, default_value = "127.0.0.1")]
+    abci_host: IpAddr,
     /// Which port should the query server listen on?
     #[clap(long, default_value = "80")]
     query: u16,
@@ -28,6 +31,7 @@ impl Run for Start {
     async fn run(self) -> color_eyre::Result<()> {
         let Self {
             abci,
+            abci_host,
             query,
             homedir,
         } = self;
@@ -61,7 +65,7 @@ impl Run for Start {
                 .consensus(consensus)
                 .finish()
                 .ok_or_eyre("could not construct ABCI server")?
-                .listen_tcp((IpAddr::V4(Ipv4Addr::LOCALHOST), abci))
+                .listen_tcp((abci_host, abci))
                 .await
                 .or_else(|e| {
                     bail!("could not start ABCI server on port {abci}: {e}");


### PR DESCRIPTION
Closes #53 

One can customize these `felidae start` args now e.g.: `felidae start --homedir /tmp/test --abci-host 127.0.0.1`
