### PR TITLE
fix: publish reliability

### DIFF
--- a/crates/felidae-publish/src/commands/print.rs
+++ b/crates/felidae-publish/src/commands/print.rs
@@ -3,11 +3,15 @@ use tendermint_rpc::HttpClient;
 
 use crate::light_block::{fetch_light_block, fetch_light_block_at_height};
 
-pub async fn print(client: &HttpClient, height: Option<u64>) -> Result<()> {
+pub async fn print(
+    client: &HttpClient,
+    height: Option<u64>,
+    timeout: std::time::Duration,
+) -> Result<()> {
     let (light_block, _) = if let Some(h) = height {
-        fetch_light_block_at_height(client, h).await?
+        fetch_light_block_at_height(client, h, timeout).await?
     } else {
-        fetch_light_block(client).await?
+        fetch_light_block(client, timeout).await?
     };
     println!("{}", serde_json::to_string_pretty(&light_block)?);
     Ok(())

--- a/crates/felidae-publish/src/commands/verify.rs
+++ b/crates/felidae-publish/src/commands/verify.rs
@@ -4,11 +4,15 @@ use tendermint_rpc::HttpClient;
 use crate::light_block::{fetch_light_block, fetch_light_block_at_height};
 use crate::verification::verify_light_block;
 
-pub async fn verify(client: &HttpClient, height: Option<u64>) -> Result<()> {
+pub async fn verify(
+    client: &HttpClient,
+    height: Option<u64>,
+    timeout: std::time::Duration,
+) -> Result<()> {
     let (light_block, status) = if let Some(h) = height {
-        fetch_light_block_at_height(client, h).await?
+        fetch_light_block_at_height(client, h, timeout).await?
     } else {
-        fetch_light_block(client).await?
+        fetch_light_block(client, timeout).await?
     };
     let chain_id = status.node_info.network.to_string();
     verify_light_block(

--- a/crates/felidae-publish/src/main.rs
+++ b/crates/felidae-publish/src/main.rs
@@ -19,6 +19,10 @@ struct Args {
     #[arg(long, default_value = "http://localhost:80")]
     query_url: String,
 
+    /// Timeout in seconds for waiting for blocks to be committed (default: 600 secs = 10 minutes)
+    #[arg(long, default_value = "600")]
+    timeout: u64,
+
     #[command(subcommand)]
     command: Command,
 }
@@ -55,10 +59,12 @@ async fn main() -> Result<()> {
     let client = HttpClient::new(rpc_url)
         .map_err(|e| color_eyre::eyre::eyre!("failed to create RPC client: {}", e))?;
 
+    let timeout = std::time::Duration::from_secs(args.timeout);
+
     match args.command {
-        Command::Print { height } => commands::print(&client, height).await?,
-        Command::Verify { height } => commands::verify(&client, height).await?,
-        Command::Reconstruct => commands::reconstruct(&client, &args.query_url).await?,
+        Command::Print { height } => commands::print(&client, height, timeout).await?,
+        Command::Verify { height } => commands::verify(&client, height, timeout).await?,
+        Command::Reconstruct => commands::reconstruct(&client, &args.query_url, timeout).await?,
     }
 
     Ok(())


### PR DESCRIPTION
In the publishing script, we were fetching the _subsequent_ block, so it makes sense that it might not have committed yet. This adds some simple logic to `felidae-publish` to retry up to a configurable timeout. 

Closes #55 