### PR TITLE
add oracle HTTP API

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -233,6 +233,28 @@ After the observation reaches quorum and the delay period expires, the observed 
 curl http://localhost/snapshot
 ```
 
+## Run Oracle as HTTP Server
+
+Instead of using the CLI, you can run the oracle as an HTTP server that accepts observation requests via API:
+
+```bash
+cargo run --bin felidae oracle server \
+  --homedir /persistent/keys \
+  --node http://localhost:26657 \
+  --port 8080
+```
+
+The server exposes two endpoints:
+- `POST /observe` - Submit observation requests (JSON: `{"domain": "example.com.", "zone": "com."}`)
+- `GET /health` - Health check endpoint
+
+Example request:
+```bash
+curl -X POST http://localhost:8080/observe \
+  -H "Content-Type: application/json" \
+  -d '{"domain": "example.com.", "zone": "com."}'
+```
+
 ## Example Scenario
 
 ### Nodes

--- a/crates/felidae/src/cli/oracle.rs
+++ b/crates/felidae/src/cli/oracle.rs
@@ -2,6 +2,7 @@ use color_eyre::eyre::OptionExt;
 use felidae_types::{FQDN, KeyPair};
 use reqwest::StatusCode;
 use reqwest::Url;
+use std::time::Duration;
 use tendermint_rpc::HttpClient;
 use tendermint_rpc::client::Client;
 
@@ -135,7 +136,11 @@ async fn observe_domain(
         .map_err(|e| color_eyre::eyre::eyre!("failed to create RPC client: {}", e))?;
 
     // We need reqwest for the enrollment endpoint:
-    let http_client = reqwest::Client::new();
+    let http_client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .connect_timeout(Duration::from_secs(5))
+        .build()
+        .map_err(|e| color_eyre::eyre::eyre!("failed to create HTTP client: {}", e))?;
 
     // Fetch the hash from the well-known endpoint of the domain/zone:
     let enrollment_string = match http_client

--- a/crates/felidae/src/cli/oracle.rs
+++ b/crates/felidae/src/cli/oracle.rs
@@ -7,6 +7,8 @@ use tendermint_rpc::client::Client;
 
 use super::Run;
 
+mod server;
+
 #[derive(clap::Subcommand)]
 pub enum Oracle {
     /// Initialize a new oracle for the network.
@@ -20,6 +22,8 @@ pub enum Oracle {
     ///
     /// This requires that the admin has already been initialized.
     Observe(Observe),
+    /// Start an HTTP API server for accepting observation requests.
+    Server(Server),
 }
 
 impl Run for Oracle {
@@ -28,6 +32,7 @@ impl Run for Oracle {
             Self::Init(cmd) => cmd.run().await,
             Self::Identity(cmd) => cmd.run().await,
             Self::Observe(cmd) => cmd.run().await,
+            Self::Server(cmd) => cmd.run().await,
         }
     }
 }
@@ -95,114 +100,138 @@ pub struct Observe {
 
 impl Run for Observe {
     async fn run(self) -> Result<(), color_eyre::Report> {
-        // Load the oracle keypair:
-        let keypair = keypair(self.homedir.as_deref()).await?;
-
-        // Create a Tendermint RPC client:
-        let rpc_url = tendermint_rpc::Url::try_from(self.node.clone())
-            .map_err(|e| color_eyre::eyre::eyre!("invalid RPC URL: {}", e))?;
-        let rpc_client = HttpClient::new(rpc_url)
-            .map_err(|e| color_eyre::eyre::eyre!("failed to create RPC client: {}", e))?;
-
-        // We need reqwest for the enrollment endpoint:
-        let http_client = reqwest::Client::new();
-
-        // Fetch the hash from the well-known endpoint of the domain/zone:
-        let enrollment_string = match http_client
-            .get(format!(
-                "https://{}/.well-known/webcat/enrollment.json",
-                self.domain.to_string().trim_matches('.')
-            ))
-            .send()
-            .await?
-            .error_for_status()
-        {
-            Ok(response) => {
-                let enrollment_string = response.text().await?;
-                Some(enrollment_string)
-            }
-            Err(error) => match error.status() {
-                // These status codes should be treated as "unenrolled":
-                Some(StatusCode::NOT_FOUND | StatusCode::GONE) => None,
-                // Any other errors should not result in an oracle observation:
-                None => {
-                    return Err(color_eyre::eyre::eyre!(
-                        "failed to fetch enrollment: {}",
-                        error
-                    ));
-                }
-                Some(status) => {
-                    return Err(color_eyre::eyre::eyre!(
-                        "unexpected status code while fetching enrollment: HTTP {} {}",
-                        status.as_u16(),
-                        status.canonical_reason().unwrap_or("")
-                    ));
-                }
-            },
-        };
-
-        if enrollment_string.is_some() {
-            info!(domain = %self.domain, "fetched enrollment");
-        } else {
-            info!(domain = %self.domain, "no enrollment found");
-        }
-
-        // Get the latest block. The app_hash in the latest block's header is the
-        // app_hash of the previous block (the last finalized block).
-        let block_result = rpc_client.latest_block().await?;
-        let block = block_result.block;
-        let latest_height = block.header.height.value();
-        let last_block_app_hash = hex::encode(block.header.app_hash.as_bytes());
-
-        // The app_hash is from the previous block, so we need to use height - 1:
-        let last_block_height = if latest_height > 0 {
-            latest_height - 1
-        } else {
-            return Err(color_eyre::eyre::eyre!(
-                "cannot get previous block: chain is at height 0"
-            ));
-        };
-
-        // Get the chain ID from the block header:
-        let chain_id = if let Some(chain_id) = self.chain {
-            chain_id
-        } else {
-            block.header.chain_id.to_string()
-        };
-
-        info!(
-            last_block_app_hash,
-            last_block_height,
-            latest_height,
-            chain_id = %chain_id,
-            "fetched latest block info"
-        );
-
-        // Create the witnessing transaction:
-        let tx = felidae_oracle::witness(
-            hex::encode(keypair.encode()?),
-            chain_id,
-            last_block_app_hash,
-            last_block_height,
-            self.domain.to_string(),
-            self.zone.to_string(),
-            enrollment_string.unwrap_or_default(),
-        )?;
-
-        // Submit the transaction to the node:
-        let tx_bytes = hex::decode(&tx)
-            .map_err(|e| color_eyre::eyre::eyre!("failed to decode transaction hex: {}", e))?;
-        let broadcast_result = rpc_client.broadcast_tx_sync(tx_bytes).await?;
-
-        info!(
-            tx = %tx,
-            code = ?broadcast_result.code,
-            hash = %hex::encode(broadcast_result.hash.as_bytes()),
-            "submitted transaction"
-        );
-
-        Ok(())
+        observe_domain(
+            self.domain,
+            self.zone,
+            self.node,
+            self.chain,
+            self.homedir.as_deref(),
+        )
+        .await
     }
+}
+
+impl Run for Server {
+    async fn run(self) -> Result<(), color_eyre::Report> {
+        server::run(self).await
+    }
+}
+
+/// Perform an observation of a domain and submit it to the chain.
+async fn observe_domain(
+    domain: FQDN,
+    zone: FQDN,
+    node: Url,
+    chain: Option<String>,
+    homedir: Option<&std::path::Path>,
+) -> Result<(), color_eyre::Report> {
+    // Load the oracle keypair:
+    let keypair = keypair(homedir).await?;
+
+    // Create a Tendermint RPC client:
+    let rpc_url = tendermint_rpc::Url::try_from(node.clone())
+        .map_err(|e| color_eyre::eyre::eyre!("invalid RPC URL: {}", e))?;
+    let rpc_client = HttpClient::new(rpc_url)
+        .map_err(|e| color_eyre::eyre::eyre!("failed to create RPC client: {}", e))?;
+
+    // We need reqwest for the enrollment endpoint:
+    let http_client = reqwest::Client::new();
+
+    // Fetch the hash from the well-known endpoint of the domain/zone:
+    let enrollment_string = match http_client
+        .get(format!(
+            "https://{}/.well-known/webcat/enrollment.json",
+            domain.to_string().trim_matches('.')
+        ))
+        .send()
+        .await?
+        .error_for_status()
+    {
+        Ok(response) => {
+            let enrollment_string = response.text().await?;
+            Some(enrollment_string)
+        }
+        Err(error) => match error.status() {
+            // These status codes should be treated as "unenrolled":
+            Some(StatusCode::NOT_FOUND | StatusCode::GONE) => None,
+            // Any other errors should not result in an oracle observation:
+            None => {
+                return Err(color_eyre::eyre::eyre!(
+                    "failed to fetch enrollment: {}",
+                    error
+                ));
+            }
+            Some(status) => {
+                return Err(color_eyre::eyre::eyre!(
+                    "unexpected status code while fetching enrollment: HTTP {} {}",
+                    status.as_u16(),
+                    status.canonical_reason().unwrap_or("")
+                ));
+            }
+        },
+    };
+
+    if enrollment_string.is_some() {
+        info!(domain = %domain, "fetched enrollment");
+    } else {
+        info!(domain = %domain, "no enrollment found");
+    }
+
+    // Get the latest block. The app_hash in the latest block's header is the
+    // app_hash of the previous block (the last finalized block).
+    let block_result = rpc_client.latest_block().await?;
+    let block = block_result.block;
+    let latest_height = block.header.height.value();
+    let last_block_app_hash = hex::encode(block.header.app_hash.as_bytes());
+
+    // The app_hash is from the previous block, so we need to use height - 1:
+    let last_block_height = if latest_height > 0 {
+        latest_height - 1
+    } else {
+        return Err(color_eyre::eyre::eyre!(
+            "cannot get previous block: chain is at height 0"
+        ));
+    };
+
+    // Get the chain ID from the block header:
+    let chain_id = if let Some(chain_id) = chain {
+        chain_id
+    } else {
+        block.header.chain_id.to_string()
+    };
+
+    info!(
+        last_block_app_hash,
+        last_block_height,
+        latest_height,
+        chain_id = %chain_id,
+        "fetched latest block info"
+    );
+
+    // Create the witnessing transaction:
+    let tx = felidae_oracle::witness(
+        hex::encode(keypair.encode()?),
+        chain_id,
+        last_block_app_hash,
+        last_block_height,
+        domain.to_string(),
+        zone.to_string(),
+        enrollment_string.unwrap_or_default(),
+    )?;
+
+    // Submit the transaction to the node:
+    let tx_bytes = hex::decode(&tx)
+        .map_err(|e| color_eyre::eyre::eyre!("failed to decode transaction hex: {}", e))?;
+    let broadcast_result = rpc_client.broadcast_tx_sync(tx_bytes).await?;
+
+    info!(
+        tx = %tx,
+        code = ?broadcast_result.code,
+        hash = %hex::encode(broadcast_result.hash.as_bytes()),
+        "submitted transaction"
+    );
+
+    Ok(())
 }
 
 async fn keypath(homedir: Option<&std::path::Path>) -> color_eyre::Result<std::path::PathBuf> {
@@ -235,4 +264,23 @@ async fn keypair(homedir: Option<&std::path::Path>) -> color_eyre::Result<KeyPai
         color_eyre::eyre::eyre!("could not parse oracle keypair at: {}", keypath.display())
     })?;
     Ok(keypair)
+}
+
+#[derive(clap::Args)]
+pub struct Server {
+    /// Which port should the API server listen on?
+    #[clap(long, default_value = "8080")]
+    pub port: u16,
+    /// Which host/address should the API server bind to?
+    #[clap(long, default_value = "0.0.0.0")]
+    pub host: String,
+    /// Node to which to send observations.
+    #[clap(long, short, default_value = "http://localhost:26657")]
+    pub node: Url,
+    /// Chain ID of the target chain (pulls from the node if not specified).
+    #[clap(long, short)]
+    pub chain: Option<String>,
+    /// Home directory for storing oracle keys (defaults to platform-specific directory).
+    #[clap(long)]
+    pub homedir: Option<std::path::PathBuf>,
 }

--- a/crates/felidae/src/cli/oracle/server.rs
+++ b/crates/felidae/src/cli/oracle/server.rs
@@ -1,0 +1,123 @@
+use axum::{Router, extract::State, http::StatusCode, response::Json, routing::post};
+use color_eyre::Report;
+use felidae_types::FQDN;
+use reqwest::Url;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tracing::info;
+
+use super::{Server, observe_domain};
+
+#[derive(Deserialize)]
+struct ObserveRequest {
+    domain: String,
+    zone: String,
+}
+
+#[derive(Serialize)]
+struct ObserveResponse {
+    success: bool,
+    message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tx_hash: Option<String>,
+}
+
+#[derive(Clone)]
+struct AppState {
+    node: Url,
+    chain: Option<String>,
+    homedir: Option<std::path::PathBuf>,
+}
+
+pub async fn run(server: Server) -> Result<(), Report> {
+    let Server {
+        port,
+        host,
+        node,
+        chain,
+        homedir,
+    } = server;
+
+    let state = Arc::new(AppState {
+        node,
+        chain,
+        homedir,
+    });
+
+    let app = Router::new()
+        .route("/observe", post(handle_observe))
+        .route("/health", axum::routing::get(|| async { "OK" }))
+        .with_state(state);
+
+    let addr = format!("{}:{}", host, port);
+    info!(addr = %addr, "starting oracle API server");
+
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    axum::serve(listener, app).await?;
+
+    Ok(())
+}
+
+async fn handle_observe(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<ObserveRequest>,
+) -> Result<Json<ObserveResponse>, (StatusCode, Json<ObserveResponse>)> {
+    // Parse domain and zone
+    let domain = match req.domain.parse::<FQDN>() {
+        Ok(d) => d,
+        Err(e) => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(ObserveResponse {
+                    success: false,
+                    message: format!("invalid domain: {}", e),
+                    tx_hash: None,
+                }),
+            ));
+        }
+    };
+
+    let zone = match req.zone.parse::<FQDN>() {
+        Ok(z) => z,
+        Err(e) => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(ObserveResponse {
+                    success: false,
+                    message: format!("invalid zone: {}", e),
+                    tx_hash: None,
+                }),
+            ));
+        }
+    };
+
+    info!(domain = %domain, zone = %zone, "received observation request");
+
+    // Perform the observation
+    match observe_domain(
+        domain,
+        zone,
+        state.node.clone(),
+        state.chain.clone(),
+        state.homedir.as_deref(),
+    )
+    .await
+    {
+        Ok(()) => Ok(Json(ObserveResponse {
+            success: true,
+            message: "observation submitted successfully".to_string(),
+            tx_hash: None, // TODO: could return tx hash if we modify observe_domain?
+        })),
+        Err(e) => {
+            info!(error = %e, "observation failed");
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ObserveResponse {
+                    success: false,
+                    message: format!("observation failed: {}", e),
+                    tx_hash: None,
+                }),
+            ))
+        }
+    }
+}


### PR DESCRIPTION
This is one piece we need for the frontend in #7. 

This PR adds an HTTP API to the oracles so that instead of from (previously) from the CLI doing:

```
RUST_LOG=info cargo run --bin felidae oracle observe --domain testapp.nym.re. --zone nym.re.
```

we can do via HTTP:

```
curl -X POST http://localhost:8080/observe \
  -H "Content-Type: application/json" \
  -d '{
    "domain": "testapp.nym.re.",
    "zone": "nym.re."
  }'
```

You should get a response like:
```
{"success":true,"message":"observation submitted successfully"}
```

The server runs via e.g.:

```
cargo run --bin felidae oracle server --port 8080 --node http://localhost:26657
```