### PR TITLE
chore: bump versions to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,7 +1069,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "felidae"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "axum 0.8.6",
  "clap",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "felidae-admin"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "felidae-types",
  "hex",
@@ -1110,7 +1110,7 @@ dependencies = [
 
 [[package]]
 name = "felidae-oracle"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64-url",
  "ed25519-dalek",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "felidae-proto"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bytes",
  "color-eyre",
@@ -1150,7 +1150,7 @@ dependencies = [
 
 [[package]]
 name = "felidae-publish"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "cnidarium",
@@ -1171,7 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "felidae-state"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cnidarium",
  "color-eyre",
@@ -1193,14 +1193,14 @@ dependencies = [
 
 [[package]]
 name = "felidae-traverse"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "prost 0.13.5",
 ]
 
 [[package]]
 name = "felidae-traverse-derive"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "proc-macro2 1.0.101",
  "quote",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "felidae-types"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "felidae-proto",
  "fqdn",

--- a/crates/felidae-admin/Cargo.toml
+++ b/crates/felidae-admin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "felidae-admin"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/felidae-oracle/Cargo.toml
+++ b/crates/felidae-oracle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "felidae-oracle"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/felidae-proto/Cargo.toml
+++ b/crates/felidae-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "felidae-proto"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/felidae-publish/Cargo.toml
+++ b/crates/felidae-publish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "felidae-publish"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [[bin]]

--- a/crates/felidae-state/Cargo.toml
+++ b/crates/felidae-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "felidae-state"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/felidae-traverse-derive/Cargo.toml
+++ b/crates/felidae-traverse-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "felidae-traverse-derive"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Derive macro for the Traverse trait"
 

--- a/crates/felidae-traverse/Cargo.toml
+++ b/crates/felidae-traverse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "felidae-traverse"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Traverse trait for visiting nested data structures"
 

--- a/crates/felidae-types/Cargo.toml
+++ b/crates/felidae-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "felidae-types"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/felidae/Cargo.toml
+++ b/crates/felidae/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "felidae"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
There was already a tag for 0.2.0, but the crate versions will still showing 0.1.0. I'm bumping the crate versions to keep pace with the advertised latest "release" on github. To bump the versions together, I ran:

  cargo release version 0.2.0  --execute

and then committed the results. We can standardize on `cargo-release` or something else to keep version bumps on rails.

Refs https://github.com/freedomofpress/webcat-infra-chain/issues/68