### PR TITLE
refactor: use bind addresses for cli

### DIFF
--- a/crates/felidae/src/cli/oracle.rs
+++ b/crates/felidae/src/cli/oracle.rs
@@ -312,12 +312,9 @@ async fn keypair(homedir: Option<&std::path::Path>) -> color_eyre::Result<KeyPai
 
 #[derive(clap::Args)]
 pub struct Server {
-    /// Which port should the API server listen on?
-    #[clap(long, default_value = "8080")]
-    pub port: u16,
-    /// Which host/address should the API server bind to?
-    #[clap(long, default_value = "0.0.0.0")]
-    pub host: String,
+    /// Socket address for the API server to bind to.
+    #[clap(long, default_value = "127.0.0.1:8081")]
+    pub bind: std::net::SocketAddr,
     /// Node to which to send observations.
     #[clap(long, short, default_value = "http://localhost:26657")]
     pub node: Url,

--- a/crates/felidae/src/cli/oracle/server.rs
+++ b/crates/felidae/src/cli/oracle/server.rs
@@ -56,8 +56,7 @@ struct AppState {
 
 pub async fn run(server: Server) -> Result<(), Report> {
     let Server {
-        port,
-        host,
+        bind,
         node,
         chain,
         homedir,
@@ -87,10 +86,9 @@ pub async fn run(server: Server) -> Result<(), Report> {
         .route("/health", axum::routing::get(|| async { "OK" }))
         .with_state(state);
 
-    let addr = format!("{}:{}", host, port);
-    info!(addr = %addr, "starting oracle API server");
+    info!(addr = %bind, "starting oracle API server");
 
-    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    let listener = tokio::net::TcpListener::bind(bind).await?;
     axum::serve(listener, app).await?;
 
     Ok(())


### PR DESCRIPTION
Updates the CLI interface for the binaries to take a single argument for bind address, rather than separate arguments for port and host that get combined. Also updates the defaults to non-privileged ports, so that binding doesn't require elevated privileges.

This is a breaking change for operators, and so the deploy logic in [0] should be updated to match.

Closes #76.

[0] https://github.com/freedomofpress/ansible-role-felidae