### PR TITLE
feat: add felidae "query" subcommand

### DIFF
--- a/crates/felidae-types/src/lib.rs
+++ b/crates/felidae-types/src/lib.rs
@@ -29,4 +29,5 @@ impl From<VerifyError> for ParseError {
     }
 }
 
+pub mod response;
 pub mod transaction;

--- a/crates/felidae-types/src/response.rs
+++ b/crates/felidae-types/src/response.rs
@@ -1,0 +1,73 @@
+//! API response types for felidae query endpoints.
+//!
+//! These types are used for serializing responses from the query API and
+//! deserializing them in clients and tests.
+
+use serde::{Deserialize, Serialize};
+use tendermint::Time;
+
+use crate::transaction::{Config, Domain, HashObserved};
+
+/// Response structure from the `/oracle/votes` query endpoint.
+///
+/// This represents a single oracle's active vote in the voting queue. Votes
+/// remain active until either:
+/// 1. Quorum is reached and the vote is consumed into a pending change
+/// 2. The vote times out (exceeds `voting.timeout` from config)
+/// 3. The same oracle submits a new vote for the same domain (overwrites)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OracleVote {
+    /// Hex-encoded ECDSA-P256 public key identifying the oracle
+    pub oracle: String,
+    /// When this vote was submitted
+    pub time: Time,
+    /// Fully qualified domain name (e.g., "example.com.")
+    pub domain: Domain,
+    /// The observed hash or NotFound indicator
+    pub hash: HashObserved,
+}
+
+/// Response structure from the `/oracle/pending` query endpoint.
+///
+/// Pending observations have reached quorum but are waiting for the delay
+/// period to expire before being promoted to canonical state. During this
+/// window:
+/// - The pending value can be viewed via this endpoint
+/// - A new quorum with a *different* value will overwrite (timer resets)
+/// - A new quorum with the *same* value is dropped (timer preserved)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingObservation {
+    /// When this pending observation was created
+    pub time: Time,
+    /// Fully qualified domain name (e.g., "example.com.")
+    pub domain: Domain,
+    /// The observed hash or NotFound indicator
+    pub hash: HashObserved,
+}
+
+/// Response structure from the `/admin/votes` query endpoint.
+///
+/// This represents a single admin's active vote for a configuration change.
+/// Unlike oracle votes which target domains, admin votes target the singleton
+/// chain configuration. The voted `config` contains the proposed new settings.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AdminVote {
+    /// Hex-encoded ECDSA-P256 public key identifying the admin
+    pub admin: String,
+    /// When this vote was submitted
+    pub time: Time,
+    /// The proposed new configuration
+    pub config: Config,
+}
+
+/// Response structure from the `/admin/pending` query endpoint.
+///
+/// Pending config changes have reached quorum but are waiting for the delay
+/// period to expire before being applied.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingConfig {
+    /// When this pending config was created
+    pub time: Time,
+    /// The proposed new configuration
+    pub config: Config,
+}

--- a/crates/felidae/Cargo.toml
+++ b/crates/felidae/Cargo.toml
@@ -2,6 +2,8 @@
 name = "felidae"
 version = "0.2.0"
 edition = "2024"
+# set felidae as default binary for the workspace
+default-run = "felidae"
 
 [dependencies]
 felidae-types = { path = "../felidae-types" }

--- a/crates/felidae/src/cli.rs
+++ b/crates/felidae/src/cli.rs
@@ -12,11 +12,15 @@ pub enum Options {
     /// Report observations as an oracle.
     #[command(subcommand)]
     Oracle(oracle::Oracle),
+    /// Query the Felidae chain state.
+    #[command(subcommand)]
+    Query(query::Query),
 }
 
 // One module per top-level subcommand
 mod admin;
 mod oracle;
+mod query;
 mod reset;
 mod start;
 
@@ -31,6 +35,7 @@ impl Run for Options {
             Self::Reset(reset) => reset.run().await,
             Self::Admin(admin) => admin.run().await,
             Self::Oracle(oracle) => oracle.run().await,
+            Self::Query(query) => query.run().await,
         }
     }
 }

--- a/crates/felidae/src/cli/query.rs
+++ b/crates/felidae/src/cli/query.rs
@@ -1,0 +1,178 @@
+//! Query subcommands for interacting with the Felidae query server.
+
+use std::collections::HashMap;
+
+use felidae_types::response::{AdminVote, OracleVote, PendingConfig, PendingObservation};
+use felidae_types::transaction::Config as ChainConfig;
+use reqwest::Url;
+
+use super::Run;
+
+#[derive(clap::Subcommand)]
+pub enum Query {
+    /// Query canonical domain→hash mappings.
+    Snapshot(Snapshot),
+    /// Query active oracle votes in the vote queue.
+    OracleVotes(OracleVotes),
+    /// Query pending oracle observations awaiting promotion.
+    OraclePending(OraclePending),
+    /// Query active admin reconfiguration votes.
+    AdminVotes(AdminVotes),
+    /// Query pending admin config changes.
+    AdminPending(AdminPending),
+    /// Query current chain configuration.
+    Config(Config),
+}
+
+impl Run for Query {
+    async fn run(self) -> color_eyre::Result<()> {
+        match self {
+            Self::Snapshot(cmd) => cmd.run().await,
+            Self::OracleVotes(cmd) => cmd.run().await,
+            Self::OraclePending(cmd) => cmd.run().await,
+            Self::AdminVotes(cmd) => cmd.run().await,
+            Self::AdminPending(cmd) => cmd.run().await,
+            Self::Config(cmd) => cmd.run().await,
+        }
+    }
+}
+
+#[derive(clap::Args)]
+pub struct Snapshot {
+    /// Felidae query server URL.
+    #[clap(long, default_value = "http://localhost:8080")]
+    pub query_url: Url,
+}
+
+impl Run for Snapshot {
+    async fn run(self) -> color_eyre::Result<()> {
+        let response: HashMap<String, String> = reqwest::Client::new()
+            .get(self.query_url.join("/snapshot")?)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+
+        println!("{}", serde_json::to_string_pretty(&response)?);
+        Ok(())
+    }
+}
+
+#[derive(clap::Args)]
+pub struct OracleVotes {
+    /// Felidae query server URL.
+    #[clap(long, default_value = "http://localhost:8080")]
+    pub query_url: Url,
+    /// Filter by domain (optional).
+    #[clap(long)]
+    pub domain: Option<String>,
+}
+
+impl Run for OracleVotes {
+    async fn run(self) -> color_eyre::Result<()> {
+        let endpoint = match &self.domain {
+            Some(domain) => format!("/oracle/votes/{}", domain),
+            None => "/oracle/votes".to_string(),
+        };
+
+        let response: Vec<OracleVote> = reqwest::Client::new()
+            .get(self.query_url.join(&endpoint)?)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+
+        println!("{}", serde_json::to_string_pretty(&response)?);
+        Ok(())
+    }
+}
+
+#[derive(clap::Args)]
+pub struct OraclePending {
+    /// Felidae query server URL.
+    #[clap(long, default_value = "http://localhost:8080")]
+    pub query_url: Url,
+}
+
+impl Run for OraclePending {
+    async fn run(self) -> color_eyre::Result<()> {
+        let response: Vec<PendingObservation> = reqwest::Client::new()
+            .get(self.query_url.join("/oracle/pending")?)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+
+        println!("{}", serde_json::to_string_pretty(&response)?);
+        Ok(())
+    }
+}
+
+#[derive(clap::Args)]
+pub struct AdminVotes {
+    /// Felidae query server URL.
+    #[clap(long, default_value = "http://localhost:8080")]
+    pub query_url: Url,
+}
+
+impl Run for AdminVotes {
+    async fn run(self) -> color_eyre::Result<()> {
+        let response: Vec<AdminVote> = reqwest::Client::new()
+            .get(self.query_url.join("/admin/votes")?)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+
+        println!("{}", serde_json::to_string_pretty(&response)?);
+        Ok(())
+    }
+}
+
+#[derive(clap::Args)]
+pub struct AdminPending {
+    /// Felidae query server URL.
+    #[clap(long, default_value = "http://localhost:8080")]
+    pub query_url: Url,
+}
+
+impl Run for AdminPending {
+    async fn run(self) -> color_eyre::Result<()> {
+        let response: Vec<PendingConfig> = reqwest::Client::new()
+            .get(self.query_url.join("/admin/pending")?)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+
+        println!("{}", serde_json::to_string_pretty(&response)?);
+        Ok(())
+    }
+}
+
+#[derive(clap::Args)]
+pub struct Config {
+    /// Felidae query server URL.
+    #[clap(long, default_value = "http://localhost:8080")]
+    pub query_url: Url,
+}
+
+impl Run for Config {
+    async fn run(self) -> color_eyre::Result<()> {
+        let response: ChainConfig = reqwest::Client::new()
+            .get(self.query_url.join("/config")?)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+
+        println!("{}", serde_json::to_string_pretty(&response)?);
+        Ok(())
+    }
+}


### PR DESCRIPTION
Adds a new "felidae query" subcommand that calls the common API routes against a node URL. Intended to improve discoverability, and aid in testing. The queryable endpoints are:

  * snapshot        Query canonical domain→hash mappings
  * oracle-votes    Query active oracle votes in the vote queue
  * oracle-pending  Query pending oracle observations awaiting promotion
  * admin-votes     Query active admin reconfiguration votes
  * admin-pending   Query pending admin config changes
  * config          Query current chain configuration

which gives pretty good coverage.