### PR TITLE
refactor: felidae query should take url once

### DIFF
--- a/crates/felidae-deployer/tests/integration/helpers.rs
+++ b/crates/felidae-deployer/tests/integration/helpers.rs
@@ -149,9 +149,9 @@ pub fn run_query_command(
 ) -> color_eyre::Result<String> {
     let mut cmd = Command::new(felidae_bin);
     cmd.arg("query")
-        .arg(subcommand)
         .arg("--query-url")
-        .arg(query_url);
+        .arg(query_url)
+        .arg(subcommand);
 
     for arg in extra_args {
         cmd.arg(arg);
@@ -170,8 +170,8 @@ pub fn run_query_command(
 
     let stdout = String::from_utf8(output.stdout)?;
     eprintln!(
-        "[run_query_command] {} --query-url {} => {}",
-        subcommand, query_url, stdout
+        "[run_query_command] --query-url {} {} => {}",
+        query_url, subcommand, stdout
     );
     Ok(stdout)
 }

--- a/crates/felidae/src/cli.rs
+++ b/crates/felidae/src/cli.rs
@@ -13,7 +13,6 @@ pub enum Options {
     #[command(subcommand)]
     Oracle(oracle::Oracle),
     /// Query the Felidae chain state.
-    #[command(subcommand)]
     Query(query::Query),
 }
 


### PR DESCRIPTION
Follow-up to #80. The initial "felidae query" interface rather sloppily required the "--query-url" flag on each of the "felidae query <foo>" sub-subcommands; now it's specified once as an argument to "felidae query" itself.

Before:

  felidae query config --query-url http://localhost:8080

After:

  felidae query --query-url http://localhost:8080 config

A small change but more intuitive. Also adds a "--node-url" alias in an attempt to be more intuitive, but there's a risk of overloading the term "node", given the architecture.