### PR TITLE
fix: emit logs by default

### DIFF
--- a/crates/felidae-deployer/src/main.rs
+++ b/crates/felidae-deployer/src/main.rs
@@ -1,5 +1,6 @@
 use clap::Parser as _;
-use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt as _, util::SubscriberInitExt as _};
+use std::io::IsTerminal as _;
+use tracing_subscriber::{EnvFilter, layer::SubscriberExt as _, util::SubscriberInitExt as _};
 
 use crate::cli::Run as _;
 
@@ -8,9 +9,19 @@ mod cli;
 #[tokio::main]
 async fn main() -> color_eyre::Result<()> {
     color_eyre::install()?;
-    tracing_subscriber::registry()
-        .with(fmt::layer())
-        .with(EnvFilter::from_default_env())
-        .init();
+    // Instantiate tracing layers.
+    // The `FmtLayer` is used to print to the console,
+    // colorizing only if we're in a tty.
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .with_ansi(std::io::stdout().is_terminal())
+        .with_writer(std::io::stderr)
+        .with_target(true);
+    // The `EnvFilter` layer is used to filter events based on `RUST_LOG`.
+    let filter_layer = EnvFilter::try_from_default_env().or_else(|_| EnvFilter::try_new("info"))?;
+    // Register the tracing subscribers.
+    let registry = tracing_subscriber::registry()
+        .with(filter_layer)
+        .with(fmt_layer);
+    registry.init();
     cli::Options::parse().run().await
 }

--- a/crates/felidae/src/main.rs
+++ b/crates/felidae/src/main.rs
@@ -2,7 +2,8 @@
 extern crate tracing;
 
 use clap::Parser as _;
-use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt as _, util::SubscriberInitExt as _};
+use std::io::IsTerminal as _;
+use tracing_subscriber::{EnvFilter, layer::SubscriberExt as _, util::SubscriberInitExt as _};
 
 use crate::cli::Run as _;
 
@@ -11,13 +12,19 @@ mod cli;
 #[tokio::main]
 async fn main() -> color_eyre::Result<()> {
     color_eyre::install()?;
+    // Instantiate tracing layers.
+    // The `FmtLayer` is used to print to the console,
+    // colorizing only if we're in a tty.
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .with_ansi(std::io::stdout().is_terminal())
+        .with_writer(std::io::stderr)
+        .with_target(true);
     // The `EnvFilter` layer is used to filter events based on `RUST_LOG`.
-    let filter_layer: EnvFilter =
-        EnvFilter::try_from_default_env().or_else(|_| EnvFilter::try_new("info"))?;
-    tracing_subscriber::registry()
-        .with(fmt::layer())
-        .with(EnvFilter::from_default_env())
+    let filter_layer = EnvFilter::try_from_default_env().or_else(|_| EnvFilter::try_new("info"))?;
+    // Register the tracing subscribers.
+    let registry = tracing_subscriber::registry()
         .with(filter_layer)
-        .init();
+        .with(fmt_layer);
+    registry.init();
     cli::Options::parse().run().await
 }


### PR DESCRIPTION
Follow up to [0], which claimed to fix logging, but crucially left in the old `.with(EnvFilter::from_default_env())` line, which overrode the logging settings to silent by default again. Fixed.

The logging goes to stderr because the "felidae" binary sometimes prints output directly to stdout, e.g. "felidae query config", and invocations like:

  RUST_LOG=debug felidae query config > config.json

should work fine, without the debug logs polluting the json file.

[0] c4772f3b8593366d60ba4a3a0c32f3c6334a1550