### PR TITLE
fix: stage previous `AppHash` in `FinalizeBlock`, add info logging

### DIFF
--- a/crates/felidae-state/src/abci.rs
+++ b/crates/felidae-state/src/abci.rs
@@ -67,9 +67,18 @@ impl Service<tendermint::v0_38::abci::Request> for crate::Store {
                 }
                 abci::Request::FinalizeBlock(finalize_block) => {
                     // Before we run the finalize block handler, we need to record the previous block's app hash.
-                    // Only for non genesis blocks.
-                    let height = store.state.write().await.block_height().await?;
+                    //
+                    // We only do this for non genesis blocks (since there's no "previous block" at genesis).
+                    let height = store
+                        .state
+                        .read()
+                        .await
+                        .block_height()
+                        .await
+                        .unwrap_or(Height::from(0u32));
+
                     info!(height = height.value(), "height in finalize block handler");
+
                     if height != Height::from(0u32) {
                         let previous_block_app_hash = store.root_hashes().await?.app_hash;
                         store

--- a/crates/felidae-state/src/abci.rs
+++ b/crates/felidae-state/src/abci.rs
@@ -76,8 +76,13 @@ impl Service<tendermint::v0_38::abci::Request> for crate::Store {
                             .state
                             .write()
                             .await
-                            .record_app_hash(previous_block_app_hash)
+                            .record_app_hash(previous_block_app_hash.clone())
                             .await?;
+                        info!(
+                            previous_block_app_hash =
+                                hex::encode(previous_block_app_hash.as_bytes()),
+                            "set app hash in finalize block handler"
+                        );
                     }
 
                     let mut response = store

--- a/crates/felidae-state/src/state/abci/finalize_block.rs
+++ b/crates/felidae-state/src/state/abci/finalize_block.rs
@@ -22,7 +22,8 @@ impl<S: StateReadExt + StateWriteExt + 'static> State<S> {
     ) -> Result<response::FinalizeBlock, Report> {
         // ABCI -> ABCI++ migration note: BeginBlock provided the Header, but FinalizeBlock
         // does not, so we can't check the chain ID as we used to do in the ABCI BeginBlock
-        // handler.
+        // handler. We also can't record the previous block's app hash from the header,
+        // but instead need to fetch it from the state, which we do in the caller.
 
         // Record validator uptime
         let mut voting_validators = BTreeSet::new();

--- a/crates/felidae-state/src/state/action/observe.rs
+++ b/crates/felidae-state/src/state/action/observe.rs
@@ -51,7 +51,8 @@ impl<S: StateReadExt + StateWriteExt + 'static> State<S> {
         }
 
         // Ensure the blockstamp's app hash matches the app hash at the given block number
-        let recorded_app_hash = self.previous_app_hash(*block_height).await?;
+        let previous_block_height = Height::from((block_height.value().saturating_sub(1)) as u32);
+        let recorded_app_hash = self.previous_app_hash(previous_block_height).await?;
         if recorded_app_hash != *app_hash {
             bail!(
                 "blockstamp app hash {app_hash} does not match recorded app hash {recorded_app_hash} for block {block_height}"

--- a/crates/felidae-state/src/state/app_hash.rs
+++ b/crates/felidae-state/src/state/app_hash.rs
@@ -1,12 +1,16 @@
+use tracing::info;
+
 use super::*;
 
 impl<S: StateReadExt + StateWriteExt + 'static> State<S> {
-    /// Record the current block's app hash in the state.
-    pub(crate) async fn record_current_app_hash(
-        &mut self,
-        app_hash: AppHash,
-    ) -> Result<(), Report> {
-        let height = self.block_height().await?.value();
+    /// Record the app hash of the previous block in the state.
+    pub(crate) async fn record_app_hash(&mut self, app_hash: AppHash) -> Result<(), Report> {
+        let height = self.block_height().await?.value() - 1;
+        info!(
+            height,
+            app_hash = hex::encode(app_hash.as_bytes()),
+            "recording app hash for block"
+        );
         self.store.put(
             Internal,
             &format!("apphash/{}", util::pad_height(height.try_into()?)),

--- a/crates/felidae-state/src/state/height.rs
+++ b/crates/felidae-state/src/state/height.rs
@@ -1,13 +1,12 @@
 use super::*;
 
 impl<S: StateReadExt + StateWriteExt + 'static> State<S> {
-    /// Get the current block height from the state, else default to 0.
+    /// Get the current block height from the state.
     pub async fn block_height(&self) -> Result<Height, Report> {
-        Ok(self
-            .store
+        self.store
             .get::<Height>(Internal, "current/block_height")
             .await?
-            .unwrap_or(Height::from(0u32)))
+            .ok_or_eyre("block height not found in state; is the state initialized?")
     }
 
     /// Set the current block height in the state.

--- a/crates/felidae-state/src/state/height.rs
+++ b/crates/felidae-state/src/state/height.rs
@@ -1,12 +1,13 @@
 use super::*;
 
 impl<S: StateReadExt + StateWriteExt + 'static> State<S> {
-    /// Get the current block height from the state.
+    /// Get the current block height from the state, else default to 0.
     pub async fn block_height(&self) -> Result<Height, Report> {
-        self.store
+        Ok(self
+            .store
             .get::<Height>(Internal, "current/block_height")
             .await?
-            .ok_or_eyre("block height not found in state; is the state initialized?")
+            .unwrap_or(Height::from(0u32)))
     }
 
     /// Set the current block height in the state.


### PR DESCRIPTION
Fixes #112 

Before we switched to ABCI++, `BeginBlock` included the header of the previous block, and during processing the `BeginBlock` message, we stored the `AppHash` for the previous block in our state. 

However, when we moved to ABCI++, `BeginBlock` no longer exists, and the new message `FinalizeBlock` does not provide the full header of the previous block. Long story short, we ended up staging the storage of the `AppHash` state change during block processing at the _end_ of `Commit`, but _after_ we persisted changes. This is the bug. If the application was interrupted _after_ `Commit` ran, then we would not persist the `AppHash`, leading to the `AppHash` mismatch in #112 due to it being missing from one validator. 

Instead, we need to stage the previous block's `AppHash` during `FinalizeBlock`. In general, any staged state must be persisted or disposed of during a single block execution cycle. 

I've tested that:
- Blocks are produced
- CometBFT + felidae can be restarted
- Domains can be enrolled
