### PR TITLE
genesis file testnet 02

### DIFF
--- a/genesis/testnet02/genesis.json
+++ b/genesis/testnet02/genesis.json
@@ -1,5 +1,5 @@
 {
-    "genesis_time": "2026-02-21T22:20:00.000000Z",
+    "genesis_time": "2026-02-22T22:20:00.000000Z",
     "chain_id": "webcat-test-02",
     "initial_height": "0",
     "consensus_params": {


### PR DESCRIPTION
This is basically the current testnet config, except I:
- decreased the oracle voting delay (the "cooldown") to 2 hours
- bumped the genesis time (though feel free to change this based on when we want the chain to start) and chain ID
- ensured that we use the correct endpoint format for the oracles (we didn't do this on start of testnet 01 and had to reconfigure)