### PR TITLE
test: integration test for validator onboarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,6 +1200,7 @@ dependencies = [
  "serde_with",
  "sha2 0.10.9",
  "tempfile",
+ "tendermint",
  "tendermint-rpc",
  "tokio",
  "toml",

--- a/crates/felidae-deployer/Cargo.toml
+++ b/crates/felidae-deployer/Cargo.toml
@@ -47,6 +47,7 @@ integration = []
 felidae = { path = "../felidae" }
 felidae-oracle = { path = "../felidae-oracle" }
 felidae-admin = { path = "../felidae-admin" }
+tendermint = { workspace = true }
 tendermint-rpc = { workspace = true }
 reqwest = { workspace = true }
 axum = { workspace = true }

--- a/crates/felidae-deployer/src/join.rs
+++ b/crates/felidae-deployer/src/join.rs
@@ -133,6 +133,17 @@ pub async fn join_network(config: JoinConfig) -> Result<WebcatNode> {
     // See GH131 for more info.
     fs::write(node.genesis_path(), &genesis_raw).wrap_err("failed to write genesis.json")?;
 
+    // Generate a priv_validator_key up front. A joined node boots as a full
+    // node (its pubkey is not in the genesis validator set), but having a
+    // consensus key pre-provisioned means the node can later be promoted to
+    // validator status via an admin reconfiguration without any manual key
+    // wrangling — the pubkey is discoverable at `priv_validator_key_path()`.
+    // Without this, CometBFT would auto-generate the key at first start,
+    // forcing callers to either race the daemon or restart the node.
+    let (priv_validator_key_json, _pub_key) = crate::network::generate_priv_validator_key()?;
+    fs::write(node.priv_validator_key_path(), priv_validator_key_json)
+        .wrap_err("failed to write priv_validator_key.json")?;
+
     // Initialize priv_validator_state (empty, since this is a full node).
     let priv_validator_state = r#"{
   "height": "0",

--- a/crates/felidae-deployer/src/network.rs
+++ b/crates/felidae-deployer/src/network.rs
@@ -615,7 +615,7 @@ fn initialize_node(node: &mut WebcatNode) -> Result<()> {
 
     // For validators, generate priv_validator_key
     if node.role.is_validator() {
-        let priv_validator_key = generate_priv_validator_key()?;
+        let (priv_validator_key, _pub_key) = generate_priv_validator_key()?;
         let mut file = fs::File::create(node.priv_validator_key_path())?;
         file.write_all(priv_validator_key.as_bytes())?;
 
@@ -666,8 +666,14 @@ pub fn generate_node_key() -> Result<(String, String)> {
     Ok((serde_json::to_string_pretty(&node_key)?, node_id))
 }
 
-/// Generate a CometBFT priv_validator_key.json.
-fn generate_priv_validator_key() -> Result<String> {
+/// Generate a CometBFT `priv_validator_key.json` body.
+///
+/// Returns `(json_string, pub_key_bytes)` where `json_string` is ready to be
+/// written to a node's `config/priv_validator_key.json` and `pub_key_bytes` is
+/// the raw 32-byte Ed25519 public key — suitable for inclusion in a felidae
+/// `Config.validators` entry when promoting a newly-joined node to validator
+/// status.
+pub fn generate_priv_validator_key() -> Result<(String, Vec<u8>)> {
     let secret_bytes: [u8; 32] = rand::random();
     let signing_key = SigningKey::from_bytes(&secret_bytes);
     let verifying_key = signing_key.verifying_key();
@@ -679,7 +685,7 @@ fn generate_priv_validator_key() -> Result<String> {
     let address = hex::encode_upper(&hash[..20]);
 
     let priv_key_bytes = signing_key.to_bytes();
-    let pub_key_bytes = verifying_key.to_bytes();
+    let pub_key_bytes = verifying_key.to_bytes().to_vec();
 
     let mut full_key = Vec::with_capacity(64);
     full_key.extend_from_slice(&priv_key_bytes);
@@ -697,7 +703,10 @@ fn generate_priv_validator_key() -> Result<String> {
         }
     });
 
-    Ok(serde_json::to_string_pretty(&priv_validator_key)?)
+    Ok((
+        serde_json::to_string_pretty(&priv_validator_key)?,
+        pub_key_bytes,
+    ))
 }
 
 /// Generate felidae admin and oracle keys as PKCS#8-encoded ECDSA-P256 keys.

--- a/crates/felidae-deployer/tests/integration/admin_tests.rs
+++ b/crates/felidae-deployer/tests/integration/admin_tests.rs
@@ -3,9 +3,13 @@
 //! This module contains tests for the admin reconfiguration system, including
 //! config updates, quorum enforcement, and BFT voting behavior.
 
-use felidae_types::transaction::{Config, OracleConfig};
+use felidae_types::response::ChainInfo;
+use felidae_types::transaction::{Config, OracleConfig, Validator};
+use std::process::{Child, Command, Stdio};
 use std::time::Duration;
 use tendermint_rpc::{Client, HttpClient};
+
+use felidae_deployer::join::{GenesisSource, JoinConfig, PeerSource};
 
 use crate::binaries::find_binaries;
 use crate::constants::{
@@ -13,7 +17,36 @@ use crate::constants::{
     inter_tx_delay, network_startup_timeout, poll_interval,
 };
 use crate::harness::TestNetwork;
-use crate::helpers::{poll_until, query_admin_pending, query_admin_votes, query_config};
+use crate::helpers::{
+    generate_ed25519_pubkey, poll_until, poll_until_async, query_admin_pending, query_admin_votes,
+    query_cometbft_validators, query_config, read_genesis_validator_pubkeys,
+    read_priv_validator_pubkey, run_query_command, submit_admin_reconfig,
+};
+
+/// Runs `felidae query chain-info --json` and parses the result.
+fn query_chain_info(
+    felidae_bin: &std::path::Path,
+    query_url: &str,
+) -> color_eyre::Result<ChainInfo> {
+    let output = run_query_command(felidae_bin, "chain-info", query_url, &["--json"])?;
+    let info: ChainInfo = serde_json::from_str(&output)?;
+    Ok(info)
+}
+
+/// RAII wrapper ensuring a joined node's child processes are reaped on drop.
+struct JoinedNodeProcs {
+    cometbft: Child,
+    felidae: Child,
+}
+
+impl Drop for JoinedNodeProcs {
+    fn drop(&mut self) {
+        let _ = self.cometbft.kill();
+        let _ = self.cometbft.wait();
+        let _ = self.felidae.kill();
+        let _ = self.felidae.wait();
+    }
+}
 
 /// Verifies that admin reconfiguration transactions work correctly.
 ///
@@ -70,38 +103,10 @@ async fn test_admin_reconfiguration() -> color_eyre::Result<()> {
         validators: current_config.validators.clone(),
     };
 
-    // Submit reconfiguration from all 3 admins to reach quorum
-    for i in 0..3 {
-        let admin_key = network.read_admin_key(i)?;
-
-        // Create the reconfiguration transaction
-        let tx_hex = felidae_admin::reconfigure(
-            &admin_key,
-            crate::constants::TEST_CHAIN_ID.to_string(),
-            admin_reconfig_tx_timeout(),
-            None, // Use default grace period
-            new_config.clone(),
-        )?;
-
-        // Submit the transaction
-        let tx_bytes = hex::decode(&tx_hex)?;
-        let result = rpc_client.broadcast_tx_commit(tx_bytes).await?;
-
-        eprintln!(
-            "[test] admin {} reconfig tx: code={:?}, log={}",
-            i, result.tx_result.code, result.tx_result.log
-        );
-
-        if !result.tx_result.code.is_ok() {
-            // First admin might succeed, subsequent may conflict - that's okay
-            eprintln!(
-                "[test] admin {} tx result code not ok: {}",
-                i, result.tx_result.log
-            );
-        }
-
-        tokio::time::sleep(inter_tx_delay()).await;
-    }
+    // Submit reconfiguration from all 3 admins to reach quorum.
+    // Uses broadcast_tx_sync (not broadcast_tx_commit) to avoid timeouts
+    // when block processing takes longer than expected in CI.
+    submit_admin_reconfig(&network, &rpc_client, new_config).await?;
 
     // Poll for the config change to take effect (admin delay is 0s in test config)
     let expected_version = current_config.version;
@@ -192,11 +197,11 @@ async fn test_admin_reconfig_minority_no_update() -> color_eyre::Result<()> {
         )?;
 
         let tx_bytes = hex::decode(&tx_hex)?;
-        let result = rpc_client.broadcast_tx_commit(tx_bytes).await?;
+        let result = rpc_client.broadcast_tx_sync(tx_bytes).await?;
 
         eprintln!(
             "[test] admin {} reconfig tx: code={:?}, log={}",
-            i, result.tx_result.code, result.tx_result.log
+            i, result.code, result.log
         );
 
         tokio::time::sleep(inter_tx_delay()).await;
@@ -310,11 +315,11 @@ async fn test_admin_reconfig_full_quorum_success() -> color_eyre::Result<()> {
         )?;
 
         let tx_bytes = hex::decode(&tx_hex)?;
-        let result = rpc_client.broadcast_tx_commit(tx_bytes).await?;
+        let result = rpc_client.broadcast_tx_sync(tx_bytes).await?;
 
         eprintln!(
             "[test] admin {} reconfig tx: code={:?}, log={}",
-            i, result.tx_result.code, result.tx_result.log
+            i, result.code, result.log
         );
 
         tokio::time::sleep(inter_tx_delay()).await;
@@ -365,6 +370,635 @@ async fn test_admin_reconfig_full_quorum_success() -> color_eyre::Result<()> {
     );
 
     eprintln!("[test] confirmed: full quorum successfully updates config");
+
+    Ok(())
+}
+
+/// Tests the full validator onboarding and offboarding lifecycle.
+///
+/// This test exercises adding and removing a validator via admin reconfiguration
+/// on a 3-validator network, verifying that both the felidae config and CometBFT's
+/// active validator set are updated correctly.
+///
+/// # Phases
+///
+/// 0. **Setup**: Start 3-validator network, verify initial state
+/// 1. **Declare genesis validators**: Populate config.validators with the 3 genesis validators
+/// 2. **Onboard 4th validator**: Add a dummy validator with power 5
+/// 3. **Offboard 4th validator**: Remove it, verify chain continues
+#[tokio::test]
+#[cfg(feature = "integration")]
+async fn test_admin_validator_onboarding_offboarding() -> color_eyre::Result<()> {
+    let (cometbft_bin, felidae_bin) = find_binaries()?;
+
+    let mut network = TestNetwork::create(3).await?;
+    network.start(
+        cometbft_bin.to_str().unwrap(),
+        felidae_bin.to_str().unwrap(),
+    )?;
+    network.wait_ready(network_startup_timeout()).await?;
+
+    let rpc_client = HttpClient::new(network.rpc_url().as_str())?;
+
+    // ── Phase 0: Verify initial state ──
+
+    let initial_config = query_config(&felidae_bin, &network.query_url())?;
+    eprintln!(
+        "[phase 0] initial config version: {}",
+        initial_config.version
+    );
+    assert!(
+        initial_config.validators.is_empty(),
+        "initial config should have no validators field"
+    );
+
+    let initial_cometbft_vals = query_cometbft_validators(&rpc_client).await?;
+    assert_eq!(
+        initial_cometbft_vals.len(),
+        3,
+        "CometBFT should have 3 genesis validators"
+    );
+    eprintln!(
+        "[phase 0] CometBFT has {} validators",
+        initial_cometbft_vals.len()
+    );
+
+    // Read the 3 genesis validator pubkeys from priv_validator_key.json files
+    let genesis_validators = read_genesis_validator_pubkeys(&network)?;
+    assert_eq!(genesis_validators.len(), 3);
+    eprintln!(
+        "[phase 0] read {} genesis validator pubkeys",
+        genesis_validators.len()
+    );
+
+    // ── Phase 1: Declare genesis validators in config ──
+
+    let phase1_config = Config {
+        version: initial_config.version + 1,
+        admins: initial_config.admins.clone(),
+        oracles: initial_config.oracles.clone(),
+        onion: initial_config.onion.clone(),
+        validators: genesis_validators.clone(),
+    };
+
+    eprintln!("[phase 1] submitting config with 3 genesis validators");
+    submit_admin_reconfig(&network, &rpc_client, phase1_config).await?;
+
+    let target_version = initial_config.version + 1;
+    poll_until(
+        consensus_propagation_wait_long(),
+        poll_interval(),
+        "phase 1: config version incremented",
+        || Ok(query_config(&felidae_bin, &network.query_url())?.version >= target_version),
+    )
+    .await?;
+
+    let config_after_phase1 = query_config(&felidae_bin, &network.query_url())?;
+    assert_eq!(
+        config_after_phase1.validators.len(),
+        3,
+        "config should have 3 validators"
+    );
+
+    // CometBFT should still have exactly 3 validators (no-op sync)
+    let cometbft_vals_phase1 = query_cometbft_validators(&rpc_client).await?;
+    assert_eq!(
+        cometbft_vals_phase1.len(),
+        3,
+        "CometBFT should still have 3 validators after declaring genesis set"
+    );
+    eprintln!("[phase 1] confirmed: 3 validators in config and CometBFT");
+
+    // ── Phase 2: Onboard a 4th validator ──
+
+    let new_pubkey = generate_ed25519_pubkey();
+    eprintln!(
+        "[phase 2] generated new validator pubkey: {}",
+        hex::encode(&new_pubkey)
+    );
+
+    let mut phase2_validators = genesis_validators.clone();
+    phase2_validators.push(Validator {
+        public_key: new_pubkey.clone().into(),
+        power: 5,
+    });
+
+    let phase2_config = Config {
+        version: config_after_phase1.version + 1,
+        admins: config_after_phase1.admins.clone(),
+        oracles: config_after_phase1.oracles.clone(),
+        onion: config_after_phase1.onion.clone(),
+        validators: phase2_validators,
+    };
+
+    eprintln!("[phase 2] submitting config with 4 validators");
+    submit_admin_reconfig(&network, &rpc_client, phase2_config).await?;
+
+    let target_version = config_after_phase1.version + 1;
+    poll_until(
+        consensus_propagation_wait_long(),
+        poll_interval(),
+        "phase 2: config version incremented",
+        || Ok(query_config(&felidae_bin, &network.query_url())?.version >= target_version),
+    )
+    .await?;
+
+    let config_after_phase2 = query_config(&felidae_bin, &network.query_url())?;
+    assert_eq!(
+        config_after_phase2.validators.len(),
+        4,
+        "config should have 4 validators"
+    );
+
+    // Poll CometBFT until it sees the 4th validator (update takes effect after FinalizeBlock)
+    poll_until_async(
+        consensus_propagation_wait_long(),
+        poll_interval(),
+        "phase 2: CometBFT sees 4 validators",
+        || async {
+            let vals = query_cometbft_validators(&rpc_client).await?;
+            Ok(vals.len() == 4)
+        },
+    )
+    .await?;
+
+    let cometbft_vals_phase2 = query_cometbft_validators(&rpc_client).await?;
+    assert_eq!(
+        cometbft_vals_phase2.len(),
+        4,
+        "CometBFT should have 4 validators"
+    );
+
+    // Verify the new validator has power 5
+    let new_val_entry = cometbft_vals_phase2
+        .iter()
+        .find(|(key, _)| key == &new_pubkey)
+        .expect("new validator should be in CometBFT validator set");
+    assert_eq!(new_val_entry.1, 5, "new validator should have power 5");
+    eprintln!("[phase 2] confirmed: 4th validator onboarded with power 5");
+
+    // ── Phase 3: Offboard the 4th validator ──
+
+    let phase3_config = Config {
+        version: config_after_phase2.version + 1,
+        admins: config_after_phase2.admins.clone(),
+        oracles: config_after_phase2.oracles.clone(),
+        onion: config_after_phase2.onion.clone(),
+        validators: genesis_validators.clone(),
+    };
+
+    eprintln!("[phase 3] submitting config with 3 validators (removing 4th)");
+    submit_admin_reconfig(&network, &rpc_client, phase3_config).await?;
+
+    let target_version = config_after_phase2.version + 1;
+    poll_until(
+        consensus_propagation_wait_long(),
+        poll_interval(),
+        "phase 3: config version incremented",
+        || Ok(query_config(&felidae_bin, &network.query_url())?.version >= target_version),
+    )
+    .await?;
+
+    let config_after_phase3 = query_config(&felidae_bin, &network.query_url())?;
+    assert_eq!(
+        config_after_phase3.validators.len(),
+        3,
+        "config should have 3 validators"
+    );
+
+    // Poll CometBFT until it shows 3 validators again
+    poll_until_async(
+        consensus_propagation_wait_long(),
+        poll_interval(),
+        "phase 3: CometBFT back to 3 validators",
+        || async {
+            let vals = query_cometbft_validators(&rpc_client).await?;
+            Ok(vals.len() == 3)
+        },
+    )
+    .await?;
+
+    let cometbft_vals_phase3 = query_cometbft_validators(&rpc_client).await?;
+    assert_eq!(
+        cometbft_vals_phase3.len(),
+        3,
+        "CometBFT should be back to 3 validators"
+    );
+    eprintln!("[phase 3] confirmed: 4th validator removed");
+
+    // Verify the chain is still producing blocks
+    let height_before = rpc_client.latest_block().await?.block.header.height.value();
+    tokio::time::sleep(consensus_propagation_wait()).await;
+    let height_after = rpc_client.latest_block().await?.block.header.height.value();
+    assert!(
+        height_after > height_before,
+        "chain should still produce blocks after validator removal (height {} → {})",
+        height_before,
+        height_after
+    );
+    eprintln!(
+        "[phase 3] chain still live: height {} → {}",
+        height_before, height_after
+    );
+
+    Ok(())
+}
+
+/// Verifies that submitting a config with an empty validators field is a no-op.
+///
+/// The `sync_validators_from_config` function treats `validators: vec![]` as
+/// "not managed by config" and leaves the active validator set untouched.
+/// This is a regression test for a bug where an empty validators field would
+/// remove all validators, halting consensus.
+#[tokio::test]
+#[cfg(feature = "integration")]
+async fn test_admin_reconfig_empty_validators_is_noop() -> color_eyre::Result<()> {
+    let (cometbft_bin, felidae_bin) = find_binaries()?;
+
+    let mut network = TestNetwork::create(3).await?;
+    network.start(
+        cometbft_bin.to_str().unwrap(),
+        felidae_bin.to_str().unwrap(),
+    )?;
+    network.wait_ready(network_startup_timeout()).await?;
+
+    let rpc_client = HttpClient::new(network.rpc_url().as_str())?;
+
+    // Get CometBFT's initial validator set
+    let initial_cometbft_vals = query_cometbft_validators(&rpc_client).await?;
+    assert_eq!(initial_cometbft_vals.len(), 3);
+
+    // Submit a reconfig with empty validators (the default)
+    let current_config = query_config(&felidae_bin, &network.query_url())?;
+    assert!(current_config.validators.is_empty());
+
+    let new_config = Config {
+        version: current_config.version + 1,
+        admins: current_config.admins.clone(),
+        oracles: OracleConfig {
+            observation_timeout: Duration::from_secs(700),
+            ..current_config.oracles.clone()
+        },
+        onion: current_config.onion.clone(),
+        validators: vec![], // explicitly empty
+    };
+
+    eprintln!("[test] submitting reconfig with empty validators");
+    submit_admin_reconfig(&network, &rpc_client, new_config).await?;
+
+    let target_version = current_config.version + 1;
+    poll_until(
+        consensus_propagation_wait_long(),
+        poll_interval(),
+        "config version incremented after empty-validators reconfig",
+        || Ok(query_config(&felidae_bin, &network.query_url())?.version >= target_version),
+    )
+    .await?;
+
+    // Verify the config was updated (observation_timeout changed)
+    let updated_config = query_config(&felidae_bin, &network.query_url())?;
+    assert_eq!(
+        updated_config.oracles.observation_timeout,
+        Duration::from_secs(700),
+        "observation_timeout should be updated"
+    );
+
+    // CometBFT should still have exactly 3 validators — empty validators is a no-op
+    let cometbft_vals_after = query_cometbft_validators(&rpc_client).await?;
+    assert_eq!(
+        cometbft_vals_after.len(),
+        3,
+        "CometBFT should still have 3 validators after empty-validators reconfig"
+    );
+    assert_eq!(
+        cometbft_vals_after, initial_cometbft_vals,
+        "validator set should be unchanged"
+    );
+
+    // Verify chain is still producing blocks
+    let height_before = rpc_client.latest_block().await?.block.header.height.value();
+    tokio::time::sleep(consensus_propagation_wait()).await;
+    let height_after = rpc_client.latest_block().await?.block.header.height.value();
+    assert!(
+        height_after > height_before,
+        "chain should still produce blocks"
+    );
+
+    eprintln!("[test] confirmed: empty validators is a no-op, chain still live");
+
+    Ok(())
+}
+
+/// End-to-end validator onboarding: bootstrap a brand-new node onto a running
+/// network via `join_network`, then promote it from full-node to validator via
+/// an admin reconfiguration, and verify the chain remains live with the
+/// expanded validator set.
+///
+/// This complements `test_admin_validator_onboarding_offboarding`, which only
+/// adds a dummy pubkey with no real node behind it. Here we exercise the full
+/// flow: a real second node joins, syncs, and is promoted to signer.
+///
+/// # Phases
+///
+/// 0. Start 3-validator devnet.
+/// 1. `join_network` as a full node. The joined node is pre-provisioned with
+///    a `priv_validator_key.json` by the join logic; we read the pubkey back
+///    from disk to feed into the later reconfig.
+/// 2. Spawn the newcomer's CometBFT + felidae processes.
+/// 3. Wait for the joined node to sync to the network's current height.
+/// 4. Declare the 3 genesis validators in `config.validators` (seeding step;
+///    the reconfig in Phase 5 must be additive, not replacing, or CometBFT
+///    would lose all signers and halt).
+/// 5. Submit an admin reconfig that adds the newcomer as a 4th validator.
+/// 6. Assert: CometBFT sees 4 validators, the chain keeps advancing on both
+///    the genesis node and the joined node, and both return identical
+///    `Config` values from their query endpoints.
+#[tokio::test]
+#[cfg(feature = "integration")]
+async fn test_validator_onboarding_joined_node() -> color_eyre::Result<()> {
+    let (cometbft_bin, felidae_bin) = find_binaries()?;
+
+    // ── Phase 0: Start devnet ──────────────────────────────────────────────
+    let mut network = TestNetwork::create(3).await?;
+    network.start(
+        cometbft_bin.to_str().unwrap(),
+        felidae_bin.to_str().unwrap(),
+    )?;
+    network.wait_ready(network_startup_timeout()).await?;
+
+    let rpc_client = HttpClient::new(network.rpc_url().as_str())?;
+
+    let initial_cometbft_vals = query_cometbft_validators(&rpc_client).await?;
+    assert_eq!(
+        initial_cometbft_vals.len(),
+        3,
+        "devnet should start with 3 validators"
+    );
+    let initial_config = query_config(&felidae_bin, &network.query_url())?;
+    assert!(
+        initial_config.validators.is_empty(),
+        "initial config.validators should be empty"
+    );
+    eprintln!("[phase 0] 3-validator devnet ready");
+
+    // ── Phase 1: Join as a full node ───────────────────────────────────────
+    // `join_network` pre-provisions a `priv_validator_key.json` for the new
+    // node, so we can read the consensus pubkey back after joining and feed
+    // it into the admin reconfig that promotes the node to validator status.
+    let join_dir = tempfile::tempdir()?;
+    let join_path = join_dir.path().join("newcomer");
+
+    let genesis_file = network.network.nodes[0].genesis_path();
+    let rpc_url: url::Url = network.rpc_url().parse()?;
+
+    let join_config = JoinConfig {
+        genesis_source: GenesisSource::File(genesis_file),
+        peer_source: PeerSource::CometbftRpc(rpc_url),
+        directory: join_path,
+        find_free_ports: true,
+        node_name: "newcomer".to_string(),
+    };
+
+    let joined = felidae_deployer::join::join_network(join_config).await?;
+
+    let new_validator_pubkey = read_priv_validator_pubkey(&joined.priv_validator_key_path())?;
+    eprintln!(
+        "[phase 1] newcomer joined; consensus pubkey: {}",
+        hex::encode(&new_validator_pubkey)
+    );
+
+    let joined_query_url = format!(
+        "http://{}:{}",
+        joined.bind_address, joined.ports.felidae_query
+    );
+
+    // ── Phase 2: Spawn the newcomer's processes ────────────────────────────
+    // Drop of JoinedNodeProcs will reap them on test exit.
+    let cometbft_child = Command::new(cometbft_bin.to_str().unwrap())
+        .args(["start", "--home", &joined.cometbft_home().to_string_lossy()])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    let felidae_child = Command::new(felidae_bin.to_str().unwrap())
+        .env("RUST_LOG", "info")
+        .args([
+            "start",
+            "--abci-bind",
+            &joined.abci_address(),
+            "--query-bind",
+            &format!("{}:{}", joined.bind_address, joined.ports.felidae_query),
+            "--homedir",
+            &joined.felidae_home().to_string_lossy(),
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    let _joined_procs = JoinedNodeProcs {
+        cometbft: cometbft_child,
+        felidae: felidae_child,
+    };
+
+    // ── Phase 3: Wait for the joined node to sync ──────────────────────────
+    let sync_target = query_chain_info(&felidae_bin, &network.query_url())?.block_height;
+    eprintln!("[phase 3] waiting for joined node to reach height {sync_target}");
+    poll_until_async(
+        network_startup_timeout(),
+        poll_interval(),
+        "joined node syncs to network height",
+        || async {
+            match query_chain_info(&felidae_bin, &joined_query_url) {
+                Ok(info) => Ok(info.block_height >= sync_target),
+                Err(_) => Ok(false),
+            }
+        },
+    )
+    .await?;
+    eprintln!("[phase 3] joined node synced");
+
+    // ── Phase 4: Seed genesis validators into config.validators ────────────
+    // We must declare the existing 3 before adding a 4th, otherwise the
+    // reconfig in Phase 5 would instruct CometBFT to replace the signers
+    // with {newcomer}, halting the chain.
+    let genesis_validators = read_genesis_validator_pubkeys(&network)?;
+    assert_eq!(genesis_validators.len(), 3);
+
+    let config_before_seed = query_config(&felidae_bin, &network.query_url())?;
+    let seed_config = Config {
+        version: config_before_seed.version + 1,
+        admins: config_before_seed.admins.clone(),
+        oracles: config_before_seed.oracles.clone(),
+        onion: config_before_seed.onion.clone(),
+        validators: genesis_validators.clone(),
+    };
+
+    eprintln!("[phase 4] seeding genesis validators into config");
+    submit_admin_reconfig(&network, &rpc_client, seed_config).await?;
+
+    let target_version = config_before_seed.version + 1;
+    poll_until(
+        consensus_propagation_wait_long(),
+        poll_interval(),
+        "phase 4: seed reconfig applied",
+        || {
+            let cfg = query_config(&felidae_bin, &network.query_url())?;
+            Ok(cfg.version >= target_version && cfg.validators.len() == 3)
+        },
+    )
+    .await?;
+
+    // CometBFT set should still be 3 (no-op at the consensus layer).
+    let cometbft_after_seed = query_cometbft_validators(&rpc_client).await?;
+    assert_eq!(
+        cometbft_after_seed.len(),
+        3,
+        "CometBFT validator set should be unchanged after seeding"
+    );
+    let config_after_seed = query_config(&felidae_bin, &network.query_url())?;
+
+    // ── Phase 5: Onboard the joined node as a 4th validator ────────────────
+    let mut phase5_validators = genesis_validators.clone();
+    phase5_validators.push(Validator {
+        public_key: new_validator_pubkey.clone().into(),
+        power: 5,
+    });
+
+    let onboard_config = Config {
+        version: config_after_seed.version + 1,
+        admins: config_after_seed.admins.clone(),
+        oracles: config_after_seed.oracles.clone(),
+        onion: config_after_seed.onion.clone(),
+        validators: phase5_validators,
+    };
+
+    eprintln!("[phase 5] onboarding newcomer as 4th validator");
+    submit_admin_reconfig(&network, &rpc_client, onboard_config).await?;
+
+    let onboard_target_version = config_after_seed.version + 1;
+    poll_until(
+        consensus_propagation_wait_long(),
+        poll_interval(),
+        "phase 5: onboarding reconfig applied in felidae config",
+        || {
+            let cfg = query_config(&felidae_bin, &network.query_url())?;
+            Ok(cfg.version >= onboard_target_version && cfg.validators.len() == 4)
+        },
+    )
+    .await?;
+
+    // Wait for CometBFT to pick up the new validator set.
+    poll_until_async(
+        consensus_propagation_wait_long(),
+        poll_interval(),
+        "phase 5: CometBFT observes 4 validators",
+        || async {
+            let vals = query_cometbft_validators(&rpc_client).await?;
+            Ok(vals.len() == 4)
+        },
+    )
+    .await?;
+
+    let cometbft_after_onboard = query_cometbft_validators(&rpc_client).await?;
+    assert_eq!(cometbft_after_onboard.len(), 4);
+    let newcomer_entry = cometbft_after_onboard
+        .iter()
+        .find(|(key, _)| key == &new_validator_pubkey)
+        .expect("newcomer should appear in CometBFT validator set");
+    assert_eq!(newcomer_entry.1, 5, "newcomer should have power 5");
+    eprintln!("[phase 5] newcomer is in the CometBFT validator set with power 5");
+
+    // ── Phase 6: Post-onboarding assertions ────────────────────────────────
+
+    // Chain liveness: poll for advancing block height on the genesis node.
+    // After a validator set change, CometBFT may briefly drop RPC connections,
+    // so we use poll_until_async rather than bare `.await?` calls.
+    // Grab a baseline height, retrying on transient connection errors.
+    let height_before = {
+        let rpc = &rpc_client;
+        let h = std::sync::atomic::AtomicU64::new(0);
+        poll_until_async(
+            consensus_propagation_wait_long(),
+            poll_interval(),
+            "phase 6: read height_before from genesis node",
+            || {
+                let h = &h;
+                async move {
+                    let resp = rpc.latest_block().await?;
+                    h.store(
+                        resp.block.header.height.value(),
+                        std::sync::atomic::Ordering::SeqCst,
+                    );
+                    Ok(true)
+                }
+            },
+        )
+        .await?;
+        h.load(std::sync::atomic::Ordering::SeqCst)
+    };
+    tokio::time::sleep(consensus_propagation_wait()).await;
+    // Check that height advanced.
+    poll_until_async(
+        consensus_propagation_wait_long(),
+        poll_interval(),
+        "phase 6: chain advances after onboarding",
+        || {
+            let rpc = &rpc_client;
+            async move {
+                let resp = rpc.latest_block().await?;
+                Ok(resp.block.header.height.value() > height_before)
+            }
+        },
+    )
+    .await?;
+    let height_after = rpc_client.latest_block().await?.block.header.height.value();
+    eprintln!(
+        "[phase 6] chain live on genesis node: {} → {}",
+        height_before, height_after
+    );
+
+    // Newcomer still tracks network height.
+    poll_until(
+        consensus_propagation_wait_long(),
+        poll_interval(),
+        "joined node stays in sync post-onboarding",
+        || {
+            let joined_info = query_chain_info(&felidae_bin, &joined_query_url)?;
+            Ok(joined_info.block_height >= height_after)
+        },
+    )
+    .await?;
+
+    // Newcomer remains a member of the active set at a later height — this is
+    // a cheap proxy for "the newcomer is actually participating". CometBFT's
+    // /validators endpoint at any given height only lists validators expected
+    // to sign at that height.
+    let later_vals = query_cometbft_validators(&rpc_client).await?;
+    assert_eq!(
+        later_vals.len(),
+        4,
+        "newcomer should remain in the active validator set at later heights"
+    );
+    assert!(
+        later_vals.iter().any(|(k, _)| k == &new_validator_pubkey),
+        "newcomer pubkey should still be in the active set"
+    );
+
+    // Config parity between genesis node and joined node: both views of
+    // state should agree post-onboarding.
+    let expected_config = query_config(&felidae_bin, &network.query_url())?;
+    let joined_config = query_config(&felidae_bin, &joined_query_url)?;
+    assert_eq!(
+        joined_config, expected_config,
+        "joined node's config should match the network's config post-onboarding"
+    );
+    assert_eq!(
+        joined_config.validators.len(),
+        4,
+        "joined node should see 4 validators in config"
+    );
+
+    eprintln!("[phase 6] confirmed: validator onboarded end-to-end, state consistent across nodes");
 
     Ok(())
 }

--- a/crates/felidae-deployer/tests/integration/constants.rs
+++ b/crates/felidae-deployer/tests/integration/constants.rs
@@ -81,9 +81,12 @@ pub fn consensus_propagation_wait() -> Duration {
     block_time() * 5
 }
 
-/// Conservative wait for quorum + promotion (10 blocks).
+/// Conservative wait for quorum + promotion (15 blocks).
+/// 10 blocks was marginal: occasional CometBFT block production stalls
+/// under load can cause admin reconfig votes to take longer than expected
+/// to land and reach quorum.
 pub fn consensus_propagation_wait_long() -> Duration {
-    block_time() * 10
+    block_time() * 15
 }
 
 /// Interval between state-check polls. `max(2s, block_time)`.

--- a/crates/felidae-deployer/tests/integration/harness.rs
+++ b/crates/felidae-deployer/tests/integration/harness.rs
@@ -106,7 +106,9 @@ impl TestNetwork {
 
             // Start Felidae
             let felidae_name = format!("{}-felidae", node.name);
+            let felidae_log = std::fs::File::create(node.home_dir.join("felidae.log"))?;
             let child = Command::new(felidae_bin)
+                .env("RUST_LOG", "info")
                 .args([
                     "start",
                     "--abci-bind",
@@ -117,7 +119,7 @@ impl TestNetwork {
                     &node.felidae_home().to_string_lossy(),
                 ])
                 .stdout(Stdio::null())
-                .stderr(Stdio::null())
+                .stderr(Stdio::from(felidae_log))
                 .spawn()?;
             self.processes.insert(felidae_name, child);
 

--- a/crates/felidae-deployer/tests/integration/helpers.rs
+++ b/crates/felidae-deployer/tests/integration/helpers.rs
@@ -9,13 +9,13 @@ use std::time::Duration;
 
 use felidae_types::response::{AdminVote, OracleVote, PendingObservation};
 use felidae_types::transaction::Config;
-use tendermint_rpc::{Client, HttpClient};
+use tendermint_rpc::{Client, HttpClient, Paging};
 
 // =============================================================================
 // POLLING UTILITIES
 // =============================================================================
 
-/// Polls a condition until it returns true or timeout is reached.
+/// Polls a synchronous condition until it returns true or timeout is reached.
 ///
 /// Useful for waiting on state changes that propagate through consensus,
 /// where the exact timing depends on block production.
@@ -31,6 +31,36 @@ pub async fn poll_until(
             Ok(true) => return Ok(()),
             Ok(false) => {}
             Err(e) => eprintln!("[poll_until] {description}: error (retrying): {e}"),
+        }
+        if start.elapsed() > timeout {
+            return Err(color_eyre::eyre::eyre!(
+                "condition not met within {timeout:?}: {description}"
+            ));
+        }
+        tokio::time::sleep(interval).await;
+    }
+}
+
+/// Polls an async condition until it returns true or timeout is reached.
+///
+/// Like `poll_until` but accepts an async check function, useful for polling
+/// async RPC calls (e.g. CometBFT validator queries).
+pub async fn poll_until_async<F, Fut>(
+    timeout: Duration,
+    interval: Duration,
+    description: &str,
+    check: F,
+) -> color_eyre::Result<()>
+where
+    F: Fn() -> Fut,
+    Fut: std::future::Future<Output = color_eyre::Result<bool>>,
+{
+    let start = std::time::Instant::now();
+    loop {
+        match check().await {
+            Ok(true) => return Ok(()),
+            Ok(false) => {}
+            Err(e) => eprintln!("[poll_until_async] {description}: error (retrying): {e}"),
         }
         if start.elapsed() > timeout {
             return Err(color_eyre::eyre::eyre!(
@@ -321,4 +351,116 @@ pub async fn run_oracle_observe(
         enrollment_json.to_owned(),
     )
     .await
+}
+
+// VALIDATOR HELPERS
+// =============================================================================
+
+/// Reads the 32-byte Ed25519 public key from a CometBFT `priv_validator_key.json`
+/// file.
+pub fn read_priv_validator_pubkey(path: &std::path::Path) -> color_eyre::Result<Vec<u8>> {
+    use base64::Engine;
+    use color_eyre::eyre::OptionExt;
+
+    let content = std::fs::read_to_string(path)?;
+    let key_json: serde_json::Value = serde_json::from_str(&content)?;
+    let b64 = key_json["pub_key"]["value"]
+        .as_str()
+        .ok_or_eyre("missing pub_key.value in priv_validator_key.json")?;
+    Ok(base64::engine::general_purpose::STANDARD.decode(b64)?)
+}
+
+/// Reads the genesis validator Ed25519 public keys from each validator node's
+/// `priv_validator_key.json` and returns them as `Validator` structs with the
+/// given power, ready for use in a `Config.validators` field.
+pub fn read_genesis_validator_pubkeys(
+    network: &crate::harness::TestNetwork,
+) -> color_eyre::Result<Vec<felidae_types::transaction::Validator>> {
+    let mut validators = Vec::new();
+    for node in network
+        .network
+        .nodes
+        .iter()
+        .filter(|n| n.role.is_validator())
+    {
+        let pub_key_bytes = read_priv_validator_pubkey(&node.priv_validator_key_path())?;
+        validators.push(felidae_types::transaction::Validator {
+            public_key: pub_key_bytes.into(),
+            power: 10,
+        });
+    }
+    Ok(validators)
+}
+
+/// Queries CometBFT's active validator set via RPC and returns (pubkey_bytes, power) tuples,
+/// sorted for deterministic comparison.
+pub async fn query_cometbft_validators(
+    rpc_client: &HttpClient,
+) -> color_eyre::Result<Vec<(Vec<u8>, u64)>> {
+    // Query at the latest height, not Height::default() which is Height(1) (genesis).
+    let latest_height = rpc_client.latest_block().await?.block.header.height;
+    let response = rpc_client.validators(latest_height, Paging::All).await?;
+    let mut result: Vec<_> = response
+        .validators
+        .iter()
+        .map(|v| {
+            let key_bytes = match v.pub_key {
+                tendermint::PublicKey::Ed25519(key) => key.as_bytes().to_vec(),
+                _ => panic!("unexpected key type"),
+            };
+            (key_bytes, v.power.value())
+        })
+        .collect();
+    result.sort();
+    Ok(result)
+}
+
+/// Generates a random Ed25519 public key for use as a dummy validator.
+pub fn generate_ed25519_pubkey() -> Vec<u8> {
+    use ed25519_dalek::SigningKey;
+    let mut secret = [0u8; 32];
+    rand::Fill::fill(&mut secret, &mut rand::rng());
+    SigningKey::from_bytes(&secret)
+        .verifying_key()
+        .to_bytes()
+        .to_vec()
+}
+
+/// Submits an admin reconfiguration from all validator nodes in the network.
+///
+/// Reads each admin key, signs and submits the reconfiguration transaction,
+/// and waits `inter_tx_delay()` between each submission.
+pub async fn submit_admin_reconfig(
+    network: &crate::harness::TestNetwork,
+    rpc_client: &HttpClient,
+    new_config: Config,
+) -> color_eyre::Result<()> {
+    let num_validators = network
+        .network
+        .nodes
+        .iter()
+        .filter(|n| n.role.is_validator())
+        .count();
+    for i in 0..num_validators {
+        let admin_key = network.read_admin_key(i)?;
+        let tx_hex = felidae_admin::reconfigure(
+            &admin_key,
+            crate::constants::TEST_CHAIN_ID.to_string(),
+            crate::constants::admin_reconfig_tx_timeout(),
+            None,
+            new_config.clone(),
+        )?;
+        let tx_bytes = hex::decode(&tx_hex)?;
+        // Use broadcast_tx_sync (submit to mempool, don't wait for block inclusion)
+        // rather than broadcast_tx_commit, which can time out when validator set
+        // updates cause longer block processing times. The subsequent polling
+        // verifies the tx took effect.
+        let result = rpc_client.broadcast_tx_sync(tx_bytes).await?;
+        eprintln!(
+            "[reconfig] admin {i}: code={:?}, log={}",
+            result.code, result.log
+        );
+        tokio::time::sleep(crate::constants::inter_tx_delay()).await;
+    }
+    Ok(())
 }


### PR DESCRIPTION
Add new integration tests exercising the validator lifecycle changes that can be triggered by admin config updates. Uses the join_network logic from #130. The tests include:

* onboarding/offboarding: seed genesis validators into config, add a 4th validator, remove it, and verify chain liveness at each phase

* setting num_vals to zero is impossible: regression test ensuring an empty validators field in a Config submission doesn't wipe the active set, which would be a catastrophic liveness failure

* end-to-end joined-node promotion: a real node joins via join_network, syncs, is promoted to validator via admin reconfig, and both nodes converge on identical state

Also adds a few helpers to make working with the tests more ergonomic. Notably there's a change from using cometbft's `broadcast_tx_commit` to `broadcast_tx_sync`, which requires polling for tx inclusion, but avoids a common timeout condition where the HTTP timeout on the `tx_commit` call was being reached, causing the tests to fail. This failure occurred sporadically, mostly under load.