### PR TITLE
fix(test): update power handling for validators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,6 +1186,7 @@ dependencies = [
  "felidae",
  "felidae-admin",
  "felidae-oracle",
+ "felidae-state",
  "felidae-types",
  "hex",
  "humantime",

--- a/crates/felidae-deployer/Cargo.toml
+++ b/crates/felidae-deployer/Cargo.toml
@@ -47,6 +47,7 @@ integration = []
 felidae = { path = "../felidae" }
 felidae-oracle = { path = "../felidae-oracle" }
 felidae-admin = { path = "../felidae-admin" }
+felidae-state = { path = "../felidae-state" }
 tendermint = { workspace = true }
 tendermint-rpc = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/felidae-deployer/tests/integration/admin_tests.rs
+++ b/crates/felidae-deployer/tests/integration/admin_tests.rs
@@ -387,7 +387,7 @@ async fn test_admin_reconfig_full_quorum_success() -> color_eyre::Result<()> {
 ///
 /// 0. **Setup**: Start 3-validator network, verify initial state
 /// 1. **Declare genesis validators**: Populate config.validators with the 3 genesis validators
-/// 2. **Onboard 4th validator**: Add a dummy validator with power 5
+/// 2. **Onboard 4th validator**: Add a dummy validator (BASE_VALIDATOR_POWER)
 /// 3. **Offboard 4th validator**: Remove it, verify chain continues
 #[tokio::test]
 #[cfg(feature = "integration")]
@@ -442,6 +442,7 @@ async fn test_admin_validator_onboarding_offboarding() -> color_eyre::Result<()>
         oracles: initial_config.oracles.clone(),
         onion: initial_config.onion.clone(),
         validators: genesis_validators.clone(),
+        validator_config: initial_config.validator_config.clone(),
     };
 
     eprintln!("[phase 1] submitting config with 3 genesis validators");
@@ -483,7 +484,6 @@ async fn test_admin_validator_onboarding_offboarding() -> color_eyre::Result<()>
     let mut phase2_validators = genesis_validators.clone();
     phase2_validators.push(Validator {
         public_key: new_pubkey.clone().into(),
-        power: 5,
     });
 
     let phase2_config = Config {
@@ -492,6 +492,7 @@ async fn test_admin_validator_onboarding_offboarding() -> color_eyre::Result<()>
         oracles: config_after_phase1.oracles.clone(),
         onion: config_after_phase1.onion.clone(),
         validators: phase2_validators,
+        validator_config: config_after_phase1.validator_config.clone(),
     };
 
     eprintln!("[phase 2] submitting config with 4 validators");
@@ -532,13 +533,19 @@ async fn test_admin_validator_onboarding_offboarding() -> color_eyre::Result<()>
         "CometBFT should have 4 validators"
     );
 
-    // Verify the new validator has power 5
+    // Verify the new validator has the canonical active power (BASE_VALIDATOR_POWER).
+    // Felidae assigns a uniform power to every active validator, ignoring any
+    // per-validator power value that might be carried in the config.
     let new_val_entry = cometbft_vals_phase2
         .iter()
         .find(|(key, _)| key == &new_pubkey)
         .expect("new validator should be in CometBFT validator set");
-    assert_eq!(new_val_entry.1, 5, "new validator should have power 5");
-    eprintln!("[phase 2] confirmed: 4th validator onboarded with power 5");
+    assert_eq!(
+        new_val_entry.1,
+        u64::from(felidae_state::BASE_VALIDATOR_POWER),
+        "new validator should have BASE_VALIDATOR_POWER"
+    );
+    eprintln!("[phase 2] confirmed: 4th validator onboarded at BASE_VALIDATOR_POWER");
 
     // ── Phase 3: Offboard the 4th validator ──
 
@@ -548,6 +555,7 @@ async fn test_admin_validator_onboarding_offboarding() -> color_eyre::Result<()>
         oracles: config_after_phase2.oracles.clone(),
         onion: config_after_phase2.onion.clone(),
         validators: genesis_validators.clone(),
+        validator_config: config_after_phase2.validator_config.clone(),
     };
 
     eprintln!("[phase 3] submitting config with 3 validators (removing 4th)");
@@ -644,6 +652,7 @@ async fn test_admin_reconfig_empty_validators_is_noop() -> color_eyre::Result<()
         },
         onion: current_config.onion.clone(),
         validators: vec![], // explicitly empty
+        validator_config: current_config.validator_config.clone(),
     };
 
     eprintln!("[test] submitting reconfig with empty validators");
@@ -834,6 +843,7 @@ async fn test_validator_onboarding_joined_node() -> color_eyre::Result<()> {
         oracles: config_before_seed.oracles.clone(),
         onion: config_before_seed.onion.clone(),
         validators: genesis_validators.clone(),
+        validator_config: config_before_seed.validator_config.clone(),
     };
 
     eprintln!("[phase 4] seeding genesis validators into config");
@@ -864,7 +874,6 @@ async fn test_validator_onboarding_joined_node() -> color_eyre::Result<()> {
     let mut phase5_validators = genesis_validators.clone();
     phase5_validators.push(Validator {
         public_key: new_validator_pubkey.clone().into(),
-        power: 5,
     });
 
     let onboard_config = Config {
@@ -873,6 +882,7 @@ async fn test_validator_onboarding_joined_node() -> color_eyre::Result<()> {
         oracles: config_after_seed.oracles.clone(),
         onion: config_after_seed.onion.clone(),
         validators: phase5_validators,
+        validator_config: config_after_seed.validator_config.clone(),
     };
 
     eprintln!("[phase 5] onboarding newcomer as 4th validator");
@@ -908,8 +918,12 @@ async fn test_validator_onboarding_joined_node() -> color_eyre::Result<()> {
         .iter()
         .find(|(key, _)| key == &new_validator_pubkey)
         .expect("newcomer should appear in CometBFT validator set");
-    assert_eq!(newcomer_entry.1, 5, "newcomer should have power 5");
-    eprintln!("[phase 5] newcomer is in the CometBFT validator set with power 5");
+    assert_eq!(
+        newcomer_entry.1,
+        u64::from(felidae_state::BASE_VALIDATOR_POWER),
+        "newcomer should have BASE_VALIDATOR_POWER"
+    );
+    eprintln!("[phase 5] newcomer is in the CometBFT validator set at BASE_VALIDATOR_POWER");
 
     // ── Phase 6: Post-onboarding assertions ────────────────────────────────
 

--- a/crates/felidae-deployer/tests/integration/helpers.rs
+++ b/crates/felidae-deployer/tests/integration/helpers.rs
@@ -386,7 +386,6 @@ pub fn read_genesis_validator_pubkeys(
         let pub_key_bytes = read_priv_validator_pubkey(&node.priv_validator_key_path())?;
         validators.push(felidae_types::transaction::Validator {
             public_key: pub_key_bytes.into(),
-            power: 10,
         });
     }
     Ok(validators)

--- a/crates/felidae-state/src/lib.rs
+++ b/crates/felidae-state/src/lib.rs
@@ -43,7 +43,7 @@ use store::{
 };
 pub use store::{Store, Substore};
 
-pub use state::Vote;
+pub use state::{BASE_VALIDATOR_POWER, Vote};
 
 /// ABCI service implementation for [`State`].
 mod abci;
@@ -104,6 +104,6 @@ mod state {
     /// Utility functions.
     mod util;
 
-    pub(crate) use validator::BASE_VALIDATOR_POWER;
+    pub use validator::BASE_VALIDATOR_POWER;
     pub use voting::Vote;
 }

--- a/crates/felidae-state/src/state/validator.rs
+++ b/crates/felidae-state/src/state/validator.rs
@@ -136,7 +136,7 @@ impl felidae_proto::DomainType for Uptime {
 /// 10^9 keeps jailed validators power of 1 negligible, fits within
 /// `i32::MAX` leaving headroom for any incidental arithmetic, and stays well within
 /// CometBFT's total-power limit of `i64::MAX / 8` even for large validator sets.
-pub(crate) const BASE_VALIDATOR_POWER: u32 = 1_000_000_000;
+pub const BASE_VALIDATOR_POWER: u32 = 1_000_000_000;
 
 impl<S: StateReadExt + StateWriteExt + 'static> State<S> {
     /// Declare a new validator by its public key.


### PR DESCRIPTION
Per-validator power is now adjusted dynamically based on validator uptime. Accordingly we must update the integration test logic to use the ValidatorConfig handling, and base checks off of that.

Notably we export the BASE_VALIDATOR_POWER constant so that it's accessible to the unit tests: this constrains us somewhat in changing this value in the future, but that's intentional, to force careful consideration as we finalize the validator power behavior.