### PR TITLE
feat: felidae query validator

### DIFF
--- a/crates/felidae-deployer/tests/integration/main.rs
+++ b/crates/felidae-deployer/tests/integration/main.rs
@@ -87,3 +87,4 @@ mod cli_tests;
 mod join_tests;
 mod oracle_tests;
 mod query_tests;
+mod validator_query_tests;

--- a/crates/felidae-deployer/tests/integration/validator_query_tests.rs
+++ b/crates/felidae-deployer/tests/integration/validator_query_tests.rs
@@ -1,0 +1,334 @@
+//! Validator query integration tests.
+//!
+//! These tests exercise the `/validators` and `/validators/{id}` HTTP routes
+//! together with the corresponding `felidae query validators [id] --json`
+//! CLI subcommand, asserting that validator status and identifying fields
+//! are reported correctly against a live 3-validator network.
+
+use std::collections::BTreeSet;
+use std::process::Command;
+
+use felidae_state::BASE_VALIDATOR_POWER;
+use felidae_types::response::ValidatorInfo;
+use sha2::{Digest, Sha256};
+use tendermint_rpc::HttpClient;
+
+use crate::binaries::find_binaries;
+use crate::constants::network_startup_timeout;
+use crate::harness::TestNetwork;
+use crate::helpers::{query_cometbft_validators, run_query_command};
+
+/// Computes a CometBFT-style 20-byte address (hex) from a 32-byte ed25519
+/// public key, matching the derivation used by `validator_info` server-side.
+fn cometbft_address_hex(pub_key_bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(pub_key_bytes);
+    let digest = hasher.finalize();
+    hex::encode(&digest[0..20])
+}
+
+/// Runs `felidae query validators [id] --json` and parses the JSON array.
+fn query_validators_cli(
+    felidae_bin: &std::path::Path,
+    query_url: &str,
+    id: Option<&str>,
+) -> color_eyre::Result<Vec<ValidatorInfo>> {
+    let extra_args: Vec<&str> = match id {
+        Some(id) => vec![id, "--json"],
+        None => vec!["--json"],
+    };
+    let output = run_query_command(felidae_bin, "validators", query_url, &extra_args)?;
+    let validators: Vec<ValidatorInfo> = serde_json::from_str(&output)?;
+    Ok(validators)
+}
+
+/// Verifies that `felidae query validators --json` returns one entry per
+/// genesis validator, all reported as `"active"` with the bootstrap power.
+///
+/// This is the happy-path test: a freshly started 3-validator network should
+/// report three active validators, with identities and CometBFT addresses
+/// matching what the CometBFT RPC reports.
+#[tokio::test]
+#[cfg(feature = "integration")]
+async fn test_validators_query_lists_active_validators() -> color_eyre::Result<()> {
+    let (cometbft_bin, felidae_bin) = find_binaries()?;
+
+    let mut network = TestNetwork::create(3).await?;
+    network.start(
+        cometbft_bin.to_str().unwrap(),
+        felidae_bin.to_str().unwrap(),
+    )?;
+    network.wait_ready(network_startup_timeout()).await?;
+
+    let validators = query_validators_cli(&felidae_bin, &network.query_url(), None)?;
+
+    assert_eq!(
+        validators.len(),
+        3,
+        "expected 3 validators in a 3-validator network, got {}: {:?}",
+        validators.len(),
+        validators
+    );
+
+    // Cross-reference identities & addresses against what CometBFT reports.
+    let rpc_client = HttpClient::new(network.rpc_url().as_str())?;
+    let cometbft_vals = query_cometbft_validators(&rpc_client).await?;
+
+    let cometbft_identities: BTreeSet<String> = cometbft_vals
+        .iter()
+        .map(|(pk, _)| hex::encode(pk))
+        .collect();
+    let reported_identities: BTreeSet<String> =
+        validators.iter().map(|v| v.identity.clone()).collect();
+    assert_eq!(
+        reported_identities, cometbft_identities,
+        "identities reported by /validators should match CometBFT's validator set"
+    );
+
+    for v in &validators {
+        assert_eq!(
+            v.status, "active",
+            "validator {} should be active in a healthy network, got {:?}",
+            v.identity, v.status
+        );
+        assert_eq!(
+            v.power,
+            u64::from(BASE_VALIDATOR_POWER),
+            "validator {} should carry BASE_VALIDATOR_POWER",
+            v.identity
+        );
+        let pub_key_bytes = hex::decode(&v.identity)?;
+        let expected_address = cometbft_address_hex(&pub_key_bytes);
+        assert_eq!(
+            v.address, expected_address,
+            "address field for {} should be the SHA-256[0..20] of the pubkey",
+            v.identity
+        );
+        // Uptime accounting fields should be populated and self-consistent.
+        assert!(
+            v.uptime_window > 0,
+            "uptime_window should be > 0 for validator {}",
+            v.identity
+        );
+        assert!(
+            v.missed_blocks <= v.uptime_window,
+            "missed_blocks ({}) should never exceed uptime_window ({}) for {}",
+            v.missed_blocks,
+            v.uptime_window,
+            v.identity,
+        );
+        assert!(
+            v.missed_blocks_max > 0,
+            "missed_blocks_max threshold should be > 0",
+        );
+        assert!(
+            v.unjail_missed_max < v.missed_blocks_max,
+            "unjail threshold ({}) should be strictly below jail threshold ({})",
+            v.unjail_missed_max,
+            v.missed_blocks_max,
+        );
+    }
+
+    eprintln!(
+        "[test] /validators reported {} active validators with matching identities",
+        validators.len()
+    );
+    Ok(())
+}
+
+/// Verifies that `felidae query validators <prefix> --json` returns exactly
+/// the matching validator. Exercises both full-id and prefix lookups, plus
+/// the leading `0x` strip behaviour implemented in the route handler.
+#[tokio::test]
+#[cfg(feature = "integration")]
+async fn test_validators_query_prefix_lookup() -> color_eyre::Result<()> {
+    let (cometbft_bin, felidae_bin) = find_binaries()?;
+
+    let mut network = TestNetwork::create(3).await?;
+    network.start(
+        cometbft_bin.to_str().unwrap(),
+        felidae_bin.to_str().unwrap(),
+    )?;
+    network.wait_ready(network_startup_timeout()).await?;
+
+    let all = query_validators_cli(&felidae_bin, &network.query_url(), None)?;
+    assert_eq!(all.len(), 3, "expected 3 validators in test network");
+    let target = &all[0];
+
+    // Full identity lookup.
+    let by_full = query_validators_cli(&felidae_bin, &network.query_url(), Some(&target.identity))?;
+    assert_eq!(
+        by_full.len(),
+        1,
+        "full-identity lookup should match exactly one validator"
+    );
+    assert_eq!(by_full[0].identity, target.identity);
+    assert_eq!(by_full[0].status, "active");
+
+    // Prefix lookup using the first 8 hex chars of the identity. The chance
+    // of a collision among 3 random ed25519 keys at 32 bits is negligible.
+    let prefix: String = target.identity.chars().take(8).collect();
+    let by_prefix = query_validators_cli(&felidae_bin, &network.query_url(), Some(&prefix))?;
+    assert_eq!(
+        by_prefix.len(),
+        1,
+        "8-char identity prefix should resolve to exactly one validator"
+    );
+    assert_eq!(by_prefix[0].identity, target.identity);
+
+    // `0x` prefix should be stripped before matching.
+    let with_0x = format!("0x{}", prefix);
+    let by_0x = query_validators_cli(&felidae_bin, &network.query_url(), Some(&with_0x))?;
+    assert_eq!(
+        by_0x.len(),
+        1,
+        "lookup with `0x` prefix should still match the validator"
+    );
+    assert_eq!(by_0x[0].identity, target.identity);
+
+    // Address lookup should also work — the route accepts either pubkey or
+    // address prefix.
+    let by_address =
+        query_validators_cli(&felidae_bin, &network.query_url(), Some(&target.address))?;
+    assert_eq!(
+        by_address.len(),
+        1,
+        "lookup by full address should resolve to exactly one validator"
+    );
+    assert_eq!(by_address[0].identity, target.identity);
+
+    Ok(())
+}
+
+/// Verifies that a lookup for a validator that does not exist surfaces an
+/// error from the CLI (the underlying route returns 404 with a plain-text
+/// body, which `error_for_status()` in the CLI promotes to a failure).
+#[tokio::test]
+#[cfg(feature = "integration")]
+async fn test_validators_query_unknown_id_errors() -> color_eyre::Result<()> {
+    let (cometbft_bin, felidae_bin) = find_binaries()?;
+
+    let mut network = TestNetwork::create(3).await?;
+    network.start(
+        cometbft_bin.to_str().unwrap(),
+        felidae_bin.to_str().unwrap(),
+    )?;
+    network.wait_ready(network_startup_timeout()).await?;
+
+    // Run the CLI directly so we can inspect both exit code and the HTTP
+    // status code surfaced to stderr.
+    let output = Command::new(&felidae_bin)
+        .args([
+            "query",
+            "--query-url",
+            &network.query_url(),
+            "validators",
+            // No real validator identity will start with this many leading f's.
+            "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            "--json",
+        ])
+        .output()?;
+
+    assert!(
+        !output.status.success(),
+        "CLI lookup of a non-existent validator id should fail; got success with stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("404"),
+        "expected 404 status in stderr, got: {stderr}"
+    );
+
+    // Confirm the route also responds 404 on the wire (independent of the
+    // CLI's behaviour).
+    let url = format!(
+        "{}/validators/ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        network.query_url()
+    );
+    let response = reqwest::Client::new().get(&url).send().await?;
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::NOT_FOUND,
+        "GET /validators/<unknown> should return 404"
+    );
+
+    Ok(())
+}
+
+/// Verifies the raw HTTP route at `/validators` returns a JSON array whose
+/// entries cover the full schema of `ValidatorInfo`. This complements the
+/// CLI tests above by exercising the route directly (so a regression that
+/// only changed the CLI wouldn't mask the route returning malformed JSON).
+#[tokio::test]
+#[cfg(feature = "integration")]
+async fn test_validators_route_returns_well_formed_json() -> color_eyre::Result<()> {
+    let (cometbft_bin, felidae_bin) = find_binaries()?;
+
+    let mut network = TestNetwork::create(3).await?;
+    network.start(
+        cometbft_bin.to_str().unwrap(),
+        felidae_bin.to_str().unwrap(),
+    )?;
+    network.wait_ready(network_startup_timeout()).await?;
+
+    let url = format!("{}/validators", network.query_url());
+    let response = reqwest::Client::new().get(&url).send().await?;
+
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::OK,
+        "GET /validators should return 200 OK"
+    );
+    let content_type = response
+        .headers()
+        .get("content-type")
+        .expect("response should have Content-Type header")
+        .to_str()?
+        .to_string();
+    assert!(
+        content_type.starts_with("application/json"),
+        "Content-Type should be application/json, got {content_type}"
+    );
+
+    // Parse twice: once as `Value` for shape checks, once as the typed
+    // `Vec<ValidatorInfo>` to confirm the schema matches what the CLI uses.
+    let body = response.text().await?;
+    let raw: serde_json::Value = serde_json::from_str(&body)?;
+    let arr = raw.as_array().expect("response should be a JSON array");
+    assert_eq!(
+        arr.len(),
+        3,
+        "expected 3 validators in array, got {}",
+        arr.len()
+    );
+    for entry in arr {
+        for key in [
+            "identity",
+            "address",
+            "power",
+            "status",
+            "missed_blocks",
+            "uptime_window",
+            "missed_blocks_max",
+            "unjail_missed_max",
+        ] {
+            assert!(
+                entry.get(key).is_some(),
+                "validator entry missing required field `{key}`: {entry}"
+            );
+        }
+    }
+
+    let typed: Vec<ValidatorInfo> = serde_json::from_str(&body)?;
+    assert_eq!(typed.len(), 3);
+    for v in &typed {
+        assert_eq!(
+            v.status, "active",
+            "validator {} should be active, got {:?}",
+            v.identity, v.status
+        );
+    }
+
+    Ok(())
+}

--- a/crates/felidae-state/src/state/validator.rs
+++ b/crates/felidae-state/src/state/validator.rs
@@ -295,6 +295,69 @@ impl<S: StateReadExt + StateWriteExt + 'static> State<S> {
         Ok(pub_keys)
     }
 
+    /// Build a list of [`ValidatorInfo`] for every validator tracked on the chain.
+    ///
+    /// This is the data source for the `/validators` query endpoint. The returned entries
+    /// cover validators in every lifecycle state (Active, Inactive, Jailed, Tombstoned);
+    /// callers can filter by [`ValidatorInfo::status`] or by `power` as needed.
+    pub async fn validator_info(
+        &self,
+    ) -> Result<Vec<felidae_types::response::ValidatorInfo>, Report> {
+        let validator_config = self.config().await?.validator_config;
+        let mut result = Vec::new();
+        let mut powers: Vec<(tendermint::PublicKey, Power)> = Vec::new();
+        {
+            let mut stream = Box::pin(self.store.prefix::<Power>(Internal, "current/validators/"));
+            while let Some(Ok((key, power))) = stream.next().await {
+                let pub_key_bytes = hex::decode(key.trim_start_matches("current/validators/"))?;
+                let pub_key = tendermint::PublicKey::from_raw_ed25519(&pub_key_bytes)
+                    .ok_or_eyre("invalid ed25519 public key")?;
+                powers.push((pub_key, power));
+            }
+        }
+        for (pub_key, power) in powers {
+            let pub_key_hex = hex::encode(pub_key.to_bytes());
+            let mut ctx = Sha256::new();
+            ctx.update(pub_key.to_bytes());
+            let hash: [u8; 32] = ctx.finalize().into();
+            let address_hex = hex::encode(&hash[0..20]);
+
+            let status = match self.validator_status(&pub_key).await? {
+                Some(ValidatorStatus::Active) => "active",
+                Some(ValidatorStatus::Inactive) => "inactive",
+                Some(ValidatorStatus::Jailed) => "jailed",
+                Some(ValidatorStatus::Tombstoned) => "tombstoned",
+                // Predates status tracking — treat as active when it still has power.
+                None if power.value() > 0 => "active",
+                None => "inactive",
+            };
+
+            let uptime: Option<Uptime> = self
+                .store
+                .get(
+                    Internal,
+                    &format!("current/validator_uptime/{}", pub_key_hex),
+                )
+                .await?;
+            let (missed_blocks, uptime_window) = match &uptime {
+                Some(u) => (u.num_missed_blocks() as u64, u.window_len() as u64),
+                None => (0, validator_config.uptime_window),
+            };
+
+            result.push(felidae_types::response::ValidatorInfo {
+                identity: pub_key_hex,
+                address: address_hex,
+                power: power.value(),
+                status: status.to_string(),
+                missed_blocks,
+                uptime_window,
+                missed_blocks_max: validator_config.missed_blocks_max,
+                unjail_missed_max: validator_config.unjail_missed_max,
+            });
+        }
+        Ok(result)
+    }
+
     /// Get all validators with non-zero power (Active and Jailed).
     ///
     /// Jailed validators carry power=1 rather than being removed from the CometBFT set,

--- a/crates/felidae-types/src/response.rs
+++ b/crates/felidae-types/src/response.rs
@@ -87,3 +87,30 @@ pub struct ChainInfo {
     /// The application state root hash (hex-encoded)
     pub app_hash: String,
 }
+
+/// Response structure from the `/validators` query endpoint.
+///
+/// Summarises a single validator's on-chain state: its identity, current
+/// voting power, status, and recent signing behaviour. The `missed_blocks`,
+/// `uptime_window`, `missed_blocks_max`, and `unjail_missed_max` fields
+/// together let a caller render signing uptime as well as compare it against
+/// the thresholds that govern jailing and unjailing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidatorInfo {
+    /// Hex-encoded ed25519 public key identifying the validator.
+    pub identity: String,
+    /// Hex-encoded CometBFT address (first 20 bytes of SHA-256 over the public key).
+    pub address: String,
+    /// Current voting power reported to CometBFT.
+    pub power: u64,
+    /// Validator status: one of `"active"`, `"inactive"`, `"jailed"`, or `"tombstoned"`.
+    pub status: String,
+    /// Number of blocks missed within the current sliding uptime window.
+    pub missed_blocks: u64,
+    /// Size of the sliding uptime window in blocks.
+    pub uptime_window: u64,
+    /// Jail threshold: once missed blocks exceeds this, the validator is jailed.
+    pub missed_blocks_max: u64,
+    /// Unjail threshold: once a jailed validator's missed blocks falls to this, it unjails.
+    pub unjail_missed_max: u64,
+}

--- a/crates/felidae/src/cli/query.rs
+++ b/crates/felidae/src/cli/query.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use felidae_types::response::{
-    AdminVote, ChainInfo, OracleVote, PendingConfig, PendingObservation,
+    AdminVote, ChainInfo, OracleVote, PendingConfig, PendingObservation, ValidatorInfo,
 };
 use felidae_types::transaction::Config as ChainConfig;
 use reqwest::Url;
@@ -40,6 +40,9 @@ pub enum QueryCommand {
     AdminPending(AdminPending),
     /// Query current chain configuration.
     Config(Config),
+    /// List validators on the chain, or look one up by id.
+    #[command(visible_alias = "validator", visible_alias = "val")]
+    Validators(Validators),
 }
 
 impl Run for Query {
@@ -53,6 +56,7 @@ impl Run for Query {
             QueryCommand::AdminVotes(cmd) => cmd.run(query_url).await,
             QueryCommand::AdminPending(cmd) => cmd.run(query_url).await,
             QueryCommand::Config(cmd) => cmd.run(query_url).await,
+            QueryCommand::Validators(cmd) => cmd.run(query_url).await,
         }
     }
 }
@@ -200,5 +204,118 @@ impl Config {
 
         println!("{}", serde_json::to_string_pretty(&response)?);
         Ok(())
+    }
+}
+
+#[derive(clap::Args)]
+pub struct Validators {
+    /// Optional validator id (full or prefix of the hex public key or address) to
+    /// restrict the listing to a single validator.
+    pub id: Option<String>,
+
+    /// Emit output as JSON instead of a human-readable table.
+    #[clap(long)]
+    pub json: bool,
+}
+
+impl Validators {
+    async fn run(self, query_url: Url) -> color_eyre::Result<()> {
+        let endpoint = match &self.id {
+            Some(id) => format!("/validators/{}", id),
+            None => "/validators".to_string(),
+        };
+
+        let validators: Vec<ValidatorInfo> = reqwest::Client::new()
+            .get(query_url.join(&endpoint)?)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+
+        if self.json {
+            println!("{}", serde_json::to_string_pretty(&validators)?);
+            return Ok(());
+        }
+
+        render_validators_table(&validators);
+        Ok(())
+    }
+}
+
+fn render_validators_table(validators: &[ValidatorInfo]) {
+    if validators.is_empty() {
+        println!("(no validators)");
+        return;
+    }
+
+    // Total power across the set so we can render each validator's share. Jailed validators
+    // carry power=1, so this stays meaningful even when some of the set is down.
+    let total_power: u128 = validators.iter().map(|v| v.power as u128).sum();
+
+    struct Row {
+        identity: String,
+        status: String,
+        power: String,
+        uptime: String,
+    }
+
+    let rows: Vec<Row> = validators
+        .iter()
+        .map(|v| {
+            let power_share = if total_power == 0 {
+                "n/a".to_string()
+            } else {
+                let pct = (v.power as f64) * 100.0 / (total_power as f64);
+                format!("{} ({:.2}%)", v.power, pct)
+            };
+            let signed = v.uptime_window.saturating_sub(v.missed_blocks);
+            let uptime_pct = if v.uptime_window == 0 {
+                "n/a".to_string()
+            } else {
+                format!("{:.2}%", (signed as f64) * 100.0 / (v.uptime_window as f64))
+            };
+            let uptime = format!("{}/{} ({})", signed, v.uptime_window, uptime_pct);
+            Row {
+                identity: v.identity.clone(),
+                status: v.status.clone(),
+                power: power_share,
+                uptime,
+            }
+        })
+        .collect();
+
+    let headers = ["IDENTITY", "STATUS", "POWER", "SIGNED/WINDOW"];
+    let mut widths = headers.map(|h| h.len());
+    for row in &rows {
+        widths[0] = widths[0].max(row.identity.len());
+        widths[1] = widths[1].max(row.status.len());
+        widths[2] = widths[2].max(row.power.len());
+        widths[3] = widths[3].max(row.uptime.len());
+    }
+
+    let print_row = |cells: [&str; 4]| {
+        println!(
+            "{:<w0$}  {:<w1$}  {:<w2$}  {:<w3$}",
+            cells[0],
+            cells[1],
+            cells[2],
+            cells[3],
+            w0 = widths[0],
+            w1 = widths[1],
+            w2 = widths[2],
+            w3 = widths[3],
+        );
+    };
+
+    print_row(headers);
+    print_row([
+        &"-".repeat(widths[0]),
+        &"-".repeat(widths[1]),
+        &"-".repeat(widths[2]),
+        &"-".repeat(widths[3]),
+    ]);
+    for row in &rows {
+        print_row([&row.identity, &row.status, &row.power, &row.uptime]);
     }
 }

--- a/crates/felidae/src/cli/start/query.rs
+++ b/crates/felidae/src/cli/start/query.rs
@@ -469,6 +469,47 @@ pub fn app(storage: Storage) -> Router {
         }
     };
 
+    let validators = || {
+        let storage = storage.clone();
+        move |filter: Option<String>| async move {
+            let state = State::new(StateDelta::new(storage.latest_snapshot()));
+            let filtered = filter.clone();
+            let get_validators = async move {
+                let mut all = state.validator_info().await?;
+                if let Some(ref id) = filtered {
+                    let needle = id.trim_start_matches("0x").to_ascii_lowercase();
+                    all.retain(|v| {
+                        v.identity.starts_with(&needle) || v.address.starts_with(&needle)
+                    });
+                }
+                Ok::<_, Report>(all)
+            };
+            match get_validators.await {
+                Err(e) => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    [("Content-Type", "text/plain")],
+                    Body::from(e.to_string()),
+                ),
+                Ok(list) => {
+                    // A single-validator lookup that finds nothing should 404 rather than
+                    // silently returning an empty array.
+                    if filter.is_some() && list.is_empty() {
+                        return (
+                            StatusCode::NOT_FOUND,
+                            [("Content-Type", "text/plain")],
+                            Body::from("no validator matched"),
+                        );
+                    }
+                    (
+                        StatusCode::OK,
+                        [("Content-Type", "application/json")],
+                        Body::from(serde_json::to_string_pretty(&list).unwrap()),
+                    )
+                }
+            }
+        }
+    };
+
     // Duplicate underlying services as needed for routing:
     let root_snapshot = snapshot();
     let domain_snapshot = snapshot();
@@ -476,6 +517,8 @@ pub fn app(storage: Storage) -> Router {
     let domain_enrollment_votes = enrollment_votes();
     let root_enrollment_pending = enrollment_pending();
     let domain_enrollment_pending = enrollment_pending();
+    let all_validators = validators();
+    let one_validator = validators();
 
     Router::new()
         .route(
@@ -547,6 +590,16 @@ pub fn app(storage: Storage) -> Router {
                         EndpointInfo {
                             path: "/admin/pending".to_string(),
                             description: "Get pending admin configuration changes".to_string(),
+                        },
+                        EndpointInfo {
+                            path: "/validators".to_string(),
+                            description: "Get info for every validator on the chain".to_string(),
+                        },
+                        EndpointInfo {
+                            path: "/validators/{id}".to_string(),
+                            description:
+                                "Get info for a single validator by pubkey or address (prefix ok)"
+                                    .to_string(),
                         },
                     ],
                 };
@@ -623,6 +676,14 @@ pub fn app(storage: Storage) -> Router {
                     Err(e) => e,
                 }
             }),
+        )
+        .route(
+            "/validators",
+            get(move || async move { all_validators(None).await }),
+        )
+        .route(
+            "/validators/{id}",
+            get(move |Path(id): Path<String>| async move { one_validator(Some(id)).await }),
         )
 }
 


### PR DESCRIPTION
Implements a new query subcommand to display validator info from a running chain. Supports single or multi validator queries, and has opt-in JSON support. Includes some tests to exercise.

## review and merging

Depends on #140, so that should be reviewed and merged first.